### PR TITLE
set up Checkstyle

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,12 +1,12 @@
 plugins {
     id("java")
     id("checkstyle")
+    id("com.github.spotbugs") version "6.0.9"
 }
 
 checkstyle {
     toolVersion = "10.12.4"
     configFile = file("config/checkstyle/checkstyle.xml")
-    id("com.github.spotbugs") version "6.0.9"
 }
 
 spotbugs {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,11 @@
 plugins {
     id("java")
+    id("checkstyle")
+}
+
+checkstyle {
+    toolVersion = "10.12.4"
+    configFile = file("config/checkstyle/checkstyle.xml")
 }
 
 group = "nu.csse.sqe"

--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0"?>
+<!DOCTYPE module PUBLIC
+        "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
+        "https://checkstyle.org/dtds/configuration_1_3.dtd">
+<module name="Checker">
+    <property name="severity" value="error"/>
+    <module name="TreeWalker">
+        <module name="WhitespaceAround"/>
+        <module name="NeedBraces"/>
+        <module name="OneStatementPerLine"/>
+        <module name="MethodLength">
+            <property name="max" value="30"/>
+        </module>
+        <module name="ParameterNumber">
+            <property name="max" value="7"/>
+        </module>
+        <module name="EmptyBlock"/>
+        <module name="LeftCurly"/>
+        <module name="RightCurly"/>
+        <module name="JavadocMethod">
+            <property name="severity" value="ignore"/>
+        </module>
+    </module>
+</module>


### PR DESCRIPTION
Set up Checkstyle with Google-style configuration. Runs automatically as part of ./gradlew build. Closes #22.