### PR TITLE
set up Jacoco

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,18 @@
 plugins {
     id("java")
+    id("jacoco")
+}
+
+jacoco {
+    toolVersion = "0.8.11"
+}
+
+tasks.jacocoTestReport {
+    dependsOn(tasks.test)
+    reports {
+        xml.required = true
+        html.required = true
+    }
 }
 
 group = "nu.csse.sqe"
@@ -26,4 +39,5 @@ tasks.compileJava {
 
 tasks.test {
     useJUnitPlatform()
+    finalizedBy(tasks.jacocoTestReport)
 }


### PR DESCRIPTION
Set up Jacoco for code coverage reporting. Generates both HTML and XML reports automatically after each test run via ./gradlew test. Closes #23.