### PR TITLE
set up SpotBugs

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,18 @@
 plugins {
     id("java")
+    id("com.github.spotbugs") version "6.0.9"
+}
+
+spotbugs {
+    toolVersion = "4.8.3"
+    effort = com.github.spotbugs.snom.Effort.MAX
+    reportLevel = com.github.spotbugs.snom.Confidence.LOW
+}
+
+tasks.spotbugsMain {
+    reports.create("html") {
+        required = true
+    }
 }
 
 group = "nu.csse.sqe"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,6 +7,7 @@ spotbugs {
     toolVersion = "4.8.3"
     effort = com.github.spotbugs.snom.Effort.MAX
     reportLevel = com.github.spotbugs.snom.Confidence.LOW
+    ignoreFailures = true
 }
 
 tasks.spotbugsMain {


### PR DESCRIPTION
Set up SpotBugs for static analysis. Configured with MAX effort and LOW confidence threshold. Generates HTML reports via ./gradlew spotbugsMain. Currently set to not fail the build since warnings are expected from stub classes. These will be addressed as implementations are completed. Closes #20.