### PR TITLE
Implement resource production

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,8 +10,8 @@ plugins {
 // Add new classes here as they are implemented and tested.
 pitest {
     junit5PluginVersion = "1.2.1"
-    targetClasses = setOf("domain.Board", "domain.Edge", "domain.Vertex")
-    targetTests = setOf("domain.BoardTest", "domain.EdgeTest", "domain.VertexTest")
+    targetClasses = setOf("domain.Board", "domain.Edge", "domain.Vertex", "domain.TerrainType")
+    targetTests = setOf("domain.BoardTest", "domain.EdgeTest", "domain.VertexTest", "domain.TerrainTypeTest")
     outputFormats = setOf("HTML")
     mutationThreshold = 100
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,8 +10,8 @@ plugins {
 // Add new classes here as they are implemented and tested.
 pitest {
     junit5PluginVersion = "1.2.1"
-    targetClasses = setOf("domain.Board", "domain.Edge", "domain.Vertex", "domain.TerrainType", "domain.Bank")
-    targetTests = setOf("domain.BoardTest", "domain.EdgeTest", "domain.VertexTest", "domain.TerrainTypeTest", "domain.BankTest")
+    targetClasses = setOf("domain.Board", "domain.Edge", "domain.Vertex", "domain.TerrainType", "domain.Bank", "domain.ResourceProduction")
+    targetTests = setOf("domain.BoardTest", "domain.EdgeTest", "domain.VertexTest", "domain.TerrainTypeTest", "domain.BankTest", "domain.ResourceProductionTest")
     outputFormats = setOf("HTML")
     mutationThreshold = 100
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,8 +10,8 @@ plugins {
 // Add new classes here as they are implemented and tested.
 pitest {
     junit5PluginVersion = "1.2.1"
-    targetClasses = setOf("domain.Board", "domain.Edge", "domain.Vertex", "domain.TerrainType")
-    targetTests = setOf("domain.BoardTest", "domain.EdgeTest", "domain.VertexTest", "domain.TerrainTypeTest")
+    targetClasses = setOf("domain.Board", "domain.Edge", "domain.Vertex", "domain.TerrainType", "domain.Bank")
+    targetTests = setOf("domain.BoardTest", "domain.EdgeTest", "domain.VertexTest", "domain.TerrainTypeTest", "domain.BankTest")
     outputFormats = setOf("HTML")
     mutationThreshold = 100
 }

--- a/docs/bva/Bank.md
+++ b/docs/bva/Bank.md
@@ -37,3 +37,10 @@
 - **TC8: Deduct_OneMoreThanAvailable_ThrowsIllegalArgumentException** ( :white_check_mark: )
     - **State of the system**: Bank with 5 BRICK, amount = 6 (one above boundary)
     - **Expected output**: `IllegalArgumentException`
+
+## Method under test: `Bank(Map<ResourceType, Integer>)` (package-private)
+
+- **TC9: PackagePrivateConstructor_WithMissingResourceType_ThrowsIllegalArgumentException** ( :white_check_mark: )
+    - **State of the system**: map contains only BRICK (missing LUMBER, ORE, GRAIN, WOOL)
+    - **Expected output**: `IllegalArgumentException` (all resource types must be present to prevent
+      `NullPointerException` on auto-unboxing in `getResourceCount`)

--- a/docs/bva/Bank.md
+++ b/docs/bva/Bank.md
@@ -1,0 +1,39 @@
+# BVA for `Bank`
+
+## Method under test: `Bank()`
+
+- **TC1: Constructor_DefaultBank_Has19OfEachResource** ( :x: )
+    - **State of the system**: `Bank()` constructed with no arguments
+    - **Expected output**: `getResourceCount()` returns `19` for each `ResourceType`
+
+## Method under test: `getResourceCount(ResourceType)`
+
+- **TC2: GetResourceCount_WithNullType_ThrowsIllegalArgumentException** ( :x: )
+    - **State of the system**: valid Bank, `null` passed as resource type
+    - **Expected output**: `IllegalArgumentException`
+
+- **TC3: GetResourceCount_WithValidType_ReturnsCurrentCount** ( :x: )
+    - **State of the system**: Bank with 5 BRICK
+    - **Expected output**: `5`
+
+## Method under test: `deduct(ResourceType, int)`
+
+- **TC4: Deduct_WithNullType_ThrowsIllegalArgumentException** ( :x: )
+    - **State of the system**: valid Bank, `null` type
+    - **Expected output**: `IllegalArgumentException`
+
+- **TC5: Deduct_WithNegativeAmount_ThrowsIllegalArgumentException** ( :x: )
+    - **State of the system**: valid Bank, amount = -1
+    - **Expected output**: `IllegalArgumentException`
+
+- **TC6: Deduct_WithZeroAmount_NoChange** ( :x: )
+    - **State of the system**: Bank with 5 BRICK, amount = 0
+    - **Expected output**: `getResourceCount(BRICK)` still returns `5`
+
+- **TC7: Deduct_ExactlyAvailableAmount_LeavesZero** ( :x: )
+    - **State of the system**: Bank with 5 BRICK, amount = 5 (at boundary)
+    - **Expected output**: `getResourceCount(BRICK)` returns `0`
+
+- **TC8: Deduct_OneMoreThanAvailable_ThrowsIllegalArgumentException** ( :x: )
+    - **State of the system**: Bank with 5 BRICK, amount = 6 (one above boundary)
+    - **Expected output**: `IllegalArgumentException`

--- a/docs/bva/Bank.md
+++ b/docs/bva/Bank.md
@@ -2,38 +2,38 @@
 
 ## Method under test: `Bank()`
 
-- **TC1: Constructor_DefaultBank_Has19OfEachResource** ( :x: )
+- **TC1: Constructor_DefaultBank_Has19OfEachResource** ( :white_check_mark: )
     - **State of the system**: `Bank()` constructed with no arguments
     - **Expected output**: `getResourceCount()` returns `19` for each `ResourceType`
 
 ## Method under test: `getResourceCount(ResourceType)`
 
-- **TC2: GetResourceCount_WithNullType_ThrowsIllegalArgumentException** ( :x: )
+- **TC2: GetResourceCount_WithNullType_ThrowsIllegalArgumentException** ( :white_check_mark: )
     - **State of the system**: valid Bank, `null` passed as resource type
     - **Expected output**: `IllegalArgumentException`
 
-- **TC3: GetResourceCount_WithValidType_ReturnsCurrentCount** ( :x: )
+- **TC3: GetResourceCount_WithValidType_ReturnsCurrentCount** ( :white_check_mark: )
     - **State of the system**: Bank with 5 BRICK
     - **Expected output**: `5`
 
 ## Method under test: `deduct(ResourceType, int)`
 
-- **TC4: Deduct_WithNullType_ThrowsIllegalArgumentException** ( :x: )
+- **TC4: Deduct_WithNullType_ThrowsIllegalArgumentException** ( :white_check_mark: )
     - **State of the system**: valid Bank, `null` type
     - **Expected output**: `IllegalArgumentException`
 
-- **TC5: Deduct_WithNegativeAmount_ThrowsIllegalArgumentException** ( :x: )
+- **TC5: Deduct_WithNegativeAmount_ThrowsIllegalArgumentException** ( :white_check_mark: )
     - **State of the system**: valid Bank, amount = -1
     - **Expected output**: `IllegalArgumentException`
 
-- **TC6: Deduct_WithZeroAmount_NoChange** ( :x: )
+- **TC6: Deduct_WithZeroAmount_NoChange** ( :white_check_mark: )
     - **State of the system**: Bank with 5 BRICK, amount = 0
     - **Expected output**: `getResourceCount(BRICK)` still returns `5`
 
-- **TC7: Deduct_ExactlyAvailableAmount_LeavesZero** ( :x: )
+- **TC7: Deduct_ExactlyAvailableAmount_LeavesZero** ( :white_check_mark: )
     - **State of the system**: Bank with 5 BRICK, amount = 5 (at boundary)
     - **Expected output**: `getResourceCount(BRICK)` returns `0`
 
-- **TC8: Deduct_OneMoreThanAvailable_ThrowsIllegalArgumentException** ( :x: )
+- **TC8: Deduct_OneMoreThanAvailable_ThrowsIllegalArgumentException** ( :white_check_mark: )
     - **State of the system**: Bank with 5 BRICK, amount = 6 (one above boundary)
     - **Expected output**: `IllegalArgumentException`

--- a/docs/bva/Board.md
+++ b/docs/bva/Board.md
@@ -175,6 +175,10 @@
   - State of the system: valid board, one adjacent vertex is occupied
   - Expected output: `false`
 
+- **TC42: SatisfiesDistanceRule_WhenTargetVertexIsOccupied_ReturnsFalse** ( :white_check_mark: )
+  - State of the system: valid board, the target vertex itself already has a settlement (no neighbors occupied)
+  - Expected output: `false` (cannot place a second settlement on an already-occupied vertex)
+
 ## Method under test: `isConnectedToPlayer(Vertex, Player)`
 - **TC38: IsConnectedToPlayer_WhenNoAdjacentRoads_ReturnsFalse** ( implemented )
   - State of the system: valid board, no edges adjacent to vertex have roads

--- a/docs/bva/ResourceProduction.md
+++ b/docs/bva/ResourceProduction.md
@@ -2,40 +2,50 @@
 
 ## Method under test: `distributeResources(int roll, List<Vertex> vertices, Bank bank)`
 
-- **TC1: DistributeResources_RollOf7_NoResourcesDistributed** ( :x: )
+- **TC1: DistributeResources_RollOf7_NoResourcesDistributed** ( :white_check_mark: )
     - **State of the system**: roll = 7, one player has a settlement, bank is full
     - **Expected output**: no player receives any resources (7 triggers robber, not production)
 
-- **TC2: DistributeResources_RollOf2_SettlementAdjacent_PlayerReceives1** ( :x: )
+- **TC2: DistributeResources_RollOf2_SettlementAdjacent_PlayerReceives1** ( :white_check_mark: )
     - **State of the system**: roll = 2 (minimum producing roll), one HILLS hex with token 2,
       one player has settlement on adjacent vertex, bank has >= 1 BRICK
     - **Expected output**: player's BRICK count increases by 1
 
-- **TC3: DistributeResources_RollOf12_SettlementAdjacent_PlayerReceives1** ( :x: )
+- **TC3: DistributeResources_RollOf12_SettlementAdjacent_PlayerReceives1** ( :white_check_mark: )
     - **State of the system**: roll = 12 (maximum producing roll), one FIELDS hex with token 12,
       one player has settlement on adjacent vertex, bank has >= 1 GRAIN
     - **Expected output**: player's GRAIN count increases by 1
 
-- **TC4: DistributeResources_CityAdjacent_PlayerReceives2** ( :x: )
+- **TC4: DistributeResources_CityAdjacent_PlayerReceives2** ( :white_check_mark: )
     - **State of the system**: roll = 6, one HILLS hex with token 6, one player has city on
       adjacent vertex (upgradeToCity called), bank has >= 2 BRICK
     - **Expected output**: player's BRICK count increases by 2
 
-- **TC5: DistributeResources_BankHas0_NoOneReceives** ( :x: )
+- **TC5: DistributeResources_BankHas0_NoOneReceives** ( :white_check_mark: )
     - **State of the system**: roll = 6, one HILLS hex with token 6, one player has settlement
       adjacent, bank has 0 BRICK
     - **Expected output**: player's BRICK count stays 0 (bank empty, distribution skipped)
 
-- **TC6: DistributeResources_UnoccupiedVertexAdjacent_NoResourceDistributed** ( :x: )
+- **TC6: DistributeResources_UnoccupiedVertexAdjacent_NoResourceDistributed** ( :white_check_mark: )
     - **State of the system**: roll = 4, one hex with token 4, all adjacent vertices unoccupied
     - **Expected output**: no player receives any resources
 
-- **TC7: DistributeResources_MultiplePlayersAdjacentSameHex_AllReceive** ( :x: )
+- **TC7: DistributeResources_MultiplePlayersAdjacentSameHex_AllReceive** ( :white_check_mark: )
     - **State of the system**: roll = 8, one HILLS hex with token 8, two different players each
       have a settlement on separate adjacent vertices, bank has >= 2 BRICK
     - **Expected output**: both players' BRICK count increases by 1 each
 
-- **TC8: DistributeResources_BankCannotCoverAll_NobodyReceives** ( :x: )
+- **TC8: DistributeResources_BankCannotCoverAll_NobodyReceives** ( :white_check_mark: )
     - **State of the system**: roll = 8, one HILLS hex with token 8, two players each have a
       settlement adjacent (total needed = 2 BRICK), bank has only 1 BRICK
     - **Expected output**: neither player receives BRICK (bank cannot fully cover demand)
+
+- **TC9: DistributeResources_BankHasExactlyEnough_ResourceDistributed** ( :white_check_mark: )
+    - **State of the system**: roll = 6, one HILLS hex with token 6, one player has settlement
+      adjacent, bank has exactly 1 BRICK (equal to needed amount)
+    - **Expected output**: player's BRICK count increases by 1 (bank at exact boundary must still distribute)
+
+- **TC10: DistributeResources_BankDeductedAfterDistribution** ( :white_check_mark: )
+    - **State of the system**: roll = 6, one HILLS hex with token 6, one player has settlement
+      adjacent, bank starts with 5 BRICK
+    - **Expected output**: bank's BRICK count is 4 after distribution (deduction actually occurred)

--- a/docs/bva/ResourceProduction.md
+++ b/docs/bva/ResourceProduction.md
@@ -1,0 +1,41 @@
+# BVA for `ResourceProduction`
+
+## Method under test: `distributeResources(int roll, List<Vertex> vertices, Bank bank)`
+
+- **TC1: DistributeResources_RollOf7_NoResourcesDistributed** ( :x: )
+    - **State of the system**: roll = 7, one player has a settlement, bank is full
+    - **Expected output**: no player receives any resources (7 triggers robber, not production)
+
+- **TC2: DistributeResources_RollOf2_SettlementAdjacent_PlayerReceives1** ( :x: )
+    - **State of the system**: roll = 2 (minimum producing roll), one HILLS hex with token 2,
+      one player has settlement on adjacent vertex, bank has >= 1 BRICK
+    - **Expected output**: player's BRICK count increases by 1
+
+- **TC3: DistributeResources_RollOf12_SettlementAdjacent_PlayerReceives1** ( :x: )
+    - **State of the system**: roll = 12 (maximum producing roll), one FIELDS hex with token 12,
+      one player has settlement on adjacent vertex, bank has >= 1 GRAIN
+    - **Expected output**: player's GRAIN count increases by 1
+
+- **TC4: DistributeResources_CityAdjacent_PlayerReceives2** ( :x: )
+    - **State of the system**: roll = 6, one HILLS hex with token 6, one player has city on
+      adjacent vertex (upgradeToCity called), bank has >= 2 BRICK
+    - **Expected output**: player's BRICK count increases by 2
+
+- **TC5: DistributeResources_BankHas0_NoOneReceives** ( :x: )
+    - **State of the system**: roll = 6, one HILLS hex with token 6, one player has settlement
+      adjacent, bank has 0 BRICK
+    - **Expected output**: player's BRICK count stays 0 (bank empty, distribution skipped)
+
+- **TC6: DistributeResources_UnoccupiedVertexAdjacent_NoResourceDistributed** ( :x: )
+    - **State of the system**: roll = 4, one hex with token 4, all adjacent vertices unoccupied
+    - **Expected output**: no player receives any resources
+
+- **TC7: DistributeResources_MultiplePlayersAdjacentSameHex_AllReceive** ( :x: )
+    - **State of the system**: roll = 8, one HILLS hex with token 8, two different players each
+      have a settlement on separate adjacent vertices, bank has >= 2 BRICK
+    - **Expected output**: both players' BRICK count increases by 1 each
+
+- **TC8: DistributeResources_BankCannotCoverAll_NobodyReceives** ( :x: )
+    - **State of the system**: roll = 8, one HILLS hex with token 8, two players each have a
+      settlement adjacent (total needed = 2 BRICK), bank has only 1 BRICK
+    - **Expected output**: neither player receives BRICK (bank cannot fully cover demand)

--- a/docs/bva/ResourceProduction.md
+++ b/docs/bva/ResourceProduction.md
@@ -49,3 +49,30 @@
     - **State of the system**: roll = 6, one HILLS hex with token 6, one player has settlement
       adjacent, bank starts with 5 BRICK
     - **Expected output**: bank's BRICK count is 4 after distribution (deduction actually occurred)
+
+- **TC11: DistributeResources_NullVertices_ThrowsIllegalArgumentException** ( :white_check_mark: )
+    - **State of the system**: `null` passed as `vertices`
+    - **Expected output**: `IllegalArgumentException`
+
+- **TC12: DistributeResources_NullBank_ThrowsIllegalArgumentException** ( :white_check_mark: )
+    - **State of the system**: `null` passed as `bank`
+    - **Expected output**: `IllegalArgumentException`
+
+- **TC13: DistributeResources_SinglePlayer_CityAdjacent_BankHasOneLessThanNeeded_PlayerReceivesWhatRemains** ( :white_check_mark: )
+    - **State of the system**: roll = 6, one HILLS hex with token 6, one player has a city on an
+      adjacent vertex (needs 2 BRICK), bank has exactly 1 BRICK (one below what the city needs)
+    - **Expected output**: player's BRICK count increases by 1 (receives what remains per Catan rules:
+      when only 1 player is affected and bank is short, that player gets as many as remain)
+
+- **TC14: DistributeResources_TwoPlayers_BankHasExactAmountNeededForBoth_BothReceive** ( :white_check_mark: )
+    - **State of the system**: roll = 8, one HILLS hex with token 8, two players each have a settlement
+      adjacent (total needed = 2 BRICK), bank has exactly 2 BRICK (at the lower boundary of "enough")
+    - **Expected output**: both players' BRICK count increases by 1 (bank exactly covering demand is
+      treated as sufficient — not as a shortfall)
+
+- **TC15: DistributeResources_TwoPlayersNeedingDifferentResources_BankShortForOne_AffectedPlayerReceivesWhatRemains** ( :white_check_mark: )
+    - **State of the system**: roll = 6, one HILLS hex (token 6) and one MOUNTAINS hex (token 6);
+      one player has a city adjacent to HILLS (needs 2 BRICK), another has a settlement adjacent to
+      MOUNTAINS (needs 1 ORE); bank has 1 BRICK (short for the city) and 19 ORE
+    - **Expected output**: city player receives 1 BRICK (single-player exception applies — only one
+      player needs BRICK), settlement player receives 1 ORE (normal distribution)

--- a/docs/bva/TerrainType.md
+++ b/docs/bva/TerrainType.md
@@ -1,0 +1,27 @@
+# BVA for `TerrainType`
+
+## Method under test: `getResourceType()`
+
+- **TC1: GetResourceType_ForHills_ReturnsBrick** ( :x: )
+    - **State of the system**: `TerrainType.HILLS`
+    - **Expected output**: `ResourceType.BRICK`
+
+- **TC2: GetResourceType_ForForest_ReturnsLumber** ( :x: )
+    - **State of the system**: `TerrainType.FOREST`
+    - **Expected output**: `ResourceType.LUMBER`
+
+- **TC3: GetResourceType_ForMountains_ReturnsOre** ( :x: )
+    - **State of the system**: `TerrainType.MOUNTAINS`
+    - **Expected output**: `ResourceType.ORE`
+
+- **TC4: GetResourceType_ForFields_ReturnsGrain** ( :x: )
+    - **State of the system**: `TerrainType.FIELDS`
+    - **Expected output**: `ResourceType.GRAIN`
+
+- **TC5: GetResourceType_ForPasture_ReturnsWool** ( :x: )
+    - **State of the system**: `TerrainType.PASTURE`
+    - **Expected output**: `ResourceType.WOOL`
+
+- **TC6: GetResourceType_ForDesert_ThrowsIllegalStateException** ( :x: )
+    - **State of the system**: `TerrainType.DESERT`
+    - **Expected output**: `IllegalStateException` (DESERT produces no resource; callers must check `producesResource()` first)

--- a/docs/bva/TerrainType.md
+++ b/docs/bva/TerrainType.md
@@ -2,26 +2,26 @@
 
 ## Method under test: `getResourceType()`
 
-- **TC1: GetResourceType_ForHills_ReturnsBrick** ( :x: )
+- **TC1: GetResourceType_ForHills_ReturnsBrick** ( :white_check_mark: )
     - **State of the system**: `TerrainType.HILLS`
     - **Expected output**: `ResourceType.BRICK`
 
-- **TC2: GetResourceType_ForForest_ReturnsLumber** ( :x: )
+- **TC2: GetResourceType_ForForest_ReturnsLumber** ( :white_check_mark: )
     - **State of the system**: `TerrainType.FOREST`
     - **Expected output**: `ResourceType.LUMBER`
 
-- **TC3: GetResourceType_ForMountains_ReturnsOre** ( :x: )
+- **TC3: GetResourceType_ForMountains_ReturnsOre** ( :white_check_mark: )
     - **State of the system**: `TerrainType.MOUNTAINS`
     - **Expected output**: `ResourceType.ORE`
 
-- **TC4: GetResourceType_ForFields_ReturnsGrain** ( :x: )
+- **TC4: GetResourceType_ForFields_ReturnsGrain** ( :white_check_mark: )
     - **State of the system**: `TerrainType.FIELDS`
     - **Expected output**: `ResourceType.GRAIN`
 
-- **TC5: GetResourceType_ForPasture_ReturnsWool** ( :x: )
+- **TC5: GetResourceType_ForPasture_ReturnsWool** ( :white_check_mark: )
     - **State of the system**: `TerrainType.PASTURE`
     - **Expected output**: `ResourceType.WOOL`
 
-- **TC6: GetResourceType_ForDesert_ThrowsIllegalStateException** ( :x: )
+- **TC6: GetResourceType_ForDesert_ThrowsIllegalStateException** ( :white_check_mark: )
     - **State of the system**: `TerrainType.DESERT`
     - **Expected output**: `IllegalStateException` (DESERT produces no resource; callers must check `producesResource()` first)

--- a/docs/bva/Vertex.md
+++ b/docs/bva/Vertex.md
@@ -66,15 +66,15 @@
 
 ## Method under test: `isCity()`
 
-- **TC14: IsCity_WhenNoOwner_ReturnsFalse** ( :x: )
+- **TC14: IsCity_WhenNoOwner_ReturnsFalse** ( :white_check_mark: )
   - State of the system: Vertex with no owner set
   - Expected output: `false`
 
-- **TC15: IsCity_WhenOwnerSetButNotUpgraded_ReturnsFalse** ( :x: )
+- **TC15: IsCity_WhenOwnerSetButNotUpgraded_ReturnsFalse** ( :white_check_mark: )
   - State of the system: Vertex with an owner set, `upgradeToCity()` not called
   - Expected output: `false`
 
-- **TC16: IsCity_AfterUpgradeToCity_ReturnsTrue** ( :x: )
+- **TC16: IsCity_AfterUpgradeToCity_ReturnsTrue** ( :white_check_mark: )
   - State of the system: Vertex with an owner set, `upgradeToCity()` called
   - Expected output: `true`
 

--- a/docs/bva/Vertex.md
+++ b/docs/bva/Vertex.md
@@ -81,3 +81,7 @@
 ## Method under test: `upgradeToCity()`
 
 - **TC17: UpgradeToCity_SetsIsCityTrue** ( implemented in TC16 )
+
+- **TC18: UpgradeToCity_WhenVertexIsUnoccupied_ThrowsIllegalStateException** ( :white_check_mark: )
+  - State of the system: Vertex with no owner set, `upgradeToCity()` called
+  - Expected output: `IllegalStateException` (a city upgrade requires an existing settlement)

--- a/docs/bva/Vertex.md
+++ b/docs/bva/Vertex.md
@@ -63,3 +63,21 @@
 - **TC13: GetAdjacentVertices_ReturnsAdjacentVertices** ( implemented )
   - State of the system: Vertex constructed with a list of adjacent vertices
   - Expected output: the same list of adjacent vertices passed in the constructor
+
+## Method under test: `isCity()`
+
+- **TC14: IsCity_WhenNoOwner_ReturnsFalse** ( :x: )
+  - State of the system: Vertex with no owner set
+  - Expected output: `false`
+
+- **TC15: IsCity_WhenOwnerSetButNotUpgraded_ReturnsFalse** ( :x: )
+  - State of the system: Vertex with an owner set, `upgradeToCity()` not called
+  - Expected output: `false`
+
+- **TC16: IsCity_AfterUpgradeToCity_ReturnsTrue** ( :x: )
+  - State of the system: Vertex with an owner set, `upgradeToCity()` called
+  - Expected output: `true`
+
+## Method under test: `upgradeToCity()`
+
+- **TC17: UpgradeToCity_SetsIsCityTrue** ( implemented in TC16 )

--- a/src/main/java/domain/Bank.java
+++ b/src/main/java/domain/Bank.java
@@ -1,0 +1,29 @@
+package domain;
+
+import java.util.EnumMap;
+import java.util.Map;
+
+public class Bank {
+
+    private static final int STANDARD_RESOURCE_COUNT = 19;
+    private final Map<ResourceType, Integer> resources;
+
+    public Bank() {
+        this.resources = new EnumMap<>(ResourceType.class);
+        for (ResourceType type : ResourceType.values()) {
+            resources.put(type, STANDARD_RESOURCE_COUNT);
+        }
+    }
+
+    Bank(Map<ResourceType, Integer> initialResources) {
+        this.resources = new EnumMap<>(initialResources);
+    }
+
+    public int getResourceCount(ResourceType type) {
+        throw new UnsupportedOperationException("Not implemented");
+    }
+
+    public void deduct(ResourceType type, int amount) {
+        throw new UnsupportedOperationException("Not implemented");
+    }
+}

--- a/src/main/java/domain/Bank.java
+++ b/src/main/java/domain/Bank.java
@@ -20,10 +20,23 @@ public class Bank {
     }
 
     public int getResourceCount(ResourceType type) {
-        throw new UnsupportedOperationException("Not implemented");
+        if (type == null) {
+            throw new IllegalArgumentException("Resource type cannot be null");
+        }
+        return resources.get(type);
     }
 
     public void deduct(ResourceType type, int amount) {
-        throw new UnsupportedOperationException("Not implemented");
+        if (type == null) {
+            throw new IllegalArgumentException("Resource type cannot be null");
+        }
+        if (amount < 0) {
+            throw new IllegalArgumentException("Amount cannot be negative");
+        }
+        int current = resources.get(type);
+        if (amount > current) {
+            throw new IllegalArgumentException("Insufficient resources in bank");
+        }
+        resources.put(type, current - amount);
     }
 }

--- a/src/main/java/domain/Bank.java
+++ b/src/main/java/domain/Bank.java
@@ -16,6 +16,11 @@ public class Bank {
     }
 
     Bank(Map<ResourceType, Integer> initialResources) {
+        for (ResourceType type : ResourceType.values()) {
+            if (!initialResources.containsKey(type)) {
+                throw new IllegalArgumentException("Initial resources must include all resource types");
+            }
+        }
         this.resources = new EnumMap<>(initialResources);
     }
 

--- a/src/main/java/domain/Board.java
+++ b/src/main/java/domain/Board.java
@@ -26,9 +26,9 @@ public final class Board {
     }
 
     Board(List<Hex> hexes, List<Vertex> vertices, List<Edge> edges) {
-        this.hexes = hexes;
-        this.vertices = vertices;
-        this.edges = edges;
+        this.hexes = new ArrayList<>(hexes);
+        this.vertices = new ArrayList<>(vertices);
+        this.edges = new ArrayList<>(edges);
     }
 
     private void validateHexCount(List<Hex> hexes) {
@@ -87,12 +87,15 @@ public final class Board {
     }
 
     public boolean satisfiesDistanceRule(Vertex vertex) {
+        if (vertex.isOccupied()) {
+            return false;
+        }
         return vertex.getAdjacentVertices().stream().noneMatch(Vertex::isOccupied);
     }
 
     public boolean isConnectedToPlayer(Vertex vertex, Player player) {
         return edges.stream()
                 .filter(e -> e.connectsTo(vertex))
-                .anyMatch(e -> e.hasRoad() && e.getOwner().get() == player);
+                .anyMatch(e -> e.getOwner().filter(o -> o == player).isPresent());
     }
 }

--- a/src/main/java/domain/ResourceProduction.java
+++ b/src/main/java/domain/ResourceProduction.java
@@ -1,10 +1,51 @@
 package domain;
 
+import java.util.EnumMap;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 
 public class ResourceProduction {
 
     public void distributeResources(int roll, List<Vertex> vertices, Bank bank) {
-        throw new UnsupportedOperationException("Not implemented");
+        if (roll == 7) {
+            return;
+        }
+
+        Map<ResourceType, Integer> totalNeeded = new EnumMap<>(ResourceType.class);
+        Map<Player, Map<ResourceType, Integer>> playerGains = new LinkedHashMap<>();
+
+        for (Vertex vertex : vertices) {
+            if (!vertex.isOccupied()) {
+                continue;
+            }
+            Player owner = vertex.getOwner().get();
+            int amount = vertex.isCity() ? 2 : 1;
+
+            for (Hex hex : vertex.getAdjacentHexes()) {
+                if (hex.getNumberToken() == roll && hex.producesResource()) {
+                    ResourceType resource = hex.getTerrainType().getResourceType();
+                    totalNeeded.merge(resource, amount, Integer::sum);
+                    playerGains
+                        .computeIfAbsent(owner, p -> new EnumMap<>(ResourceType.class))
+                        .merge(resource, amount, Integer::sum);
+                }
+            }
+        }
+
+        for (ResourceType resource : totalNeeded.keySet()) {
+            int needed = totalNeeded.get(resource);
+            if (bank.getResourceCount(resource) < needed) {
+                continue;
+            }
+            for (Map.Entry<Player, Map<ResourceType, Integer>> entry : playerGains.entrySet()) {
+                Integer gain = entry.getValue().get(resource);
+                if (gain != null) {
+                    entry.getKey().addResources(resource, gain);
+                }
+            }
+            bank.deduct(resource, needed);
+        }
     }
 }
+

--- a/src/main/java/domain/ResourceProduction.java
+++ b/src/main/java/domain/ResourceProduction.java
@@ -1,0 +1,10 @@
+package domain;
+
+import java.util.List;
+
+public class ResourceProduction {
+
+    public void distributeResources(int roll, List<Vertex> vertices, Bank bank) {
+        throw new UnsupportedOperationException("Not implemented");
+    }
+}

--- a/src/main/java/domain/ResourceProduction.java
+++ b/src/main/java/domain/ResourceProduction.java
@@ -8,20 +8,30 @@ import java.util.Map;
 public class ResourceProduction {
 
     public void distributeResources(int roll, List<Vertex> vertices, Bank bank) {
+        if (vertices == null) {
+            throw new IllegalArgumentException("Vertices cannot be null");
+        }
+        if (bank == null) {
+            throw new IllegalArgumentException("Bank cannot be null");
+        }
         if (roll == 7) {
             return;
         }
-
         Map<ResourceType, Integer> totalNeeded = new EnumMap<>(ResourceType.class);
         Map<Player, Map<ResourceType, Integer>> playerGains = new LinkedHashMap<>();
+        collectGains(roll, vertices, totalNeeded, playerGains);
+        distributeToPlayers(totalNeeded, playerGains, bank);
+    }
 
+    private void collectGains(int roll, List<Vertex> vertices,
+            Map<ResourceType, Integer> totalNeeded,
+            Map<Player, Map<ResourceType, Integer>> playerGains) {
         for (Vertex vertex : vertices) {
             if (!vertex.isOccupied()) {
                 continue;
             }
             Player owner = vertex.getOwner().get();
             int amount = vertex.isCity() ? 2 : 1;
-
             for (Hex hex : vertex.getAdjacentHexes()) {
                 if (hex.getNumberToken() == roll && hex.producesResource()) {
                     ResourceType resource = hex.getTerrainType().getResourceType();
@@ -32,10 +42,22 @@ public class ResourceProduction {
                 }
             }
         }
+    }
 
+    private void distributeToPlayers(
+            Map<ResourceType, Integer> totalNeeded,
+            Map<Player, Map<ResourceType, Integer>> playerGains,
+            Bank bank) {
         for (ResourceType resource : totalNeeded.keySet()) {
             int needed = totalNeeded.get(resource);
-            if (bank.getResourceCount(resource) < needed) {
+            int available = bank.getResourceCount(resource);
+            if (available < needed) {
+                long affectedCount = playerGains.values().stream()
+                        .filter(m -> m.containsKey(resource)).count();
+                if (affectedCount > 1) {
+                    continue;
+                }
+                giveRemainingToSinglePlayer(resource, available, playerGains, bank);
                 continue;
             }
             for (Map.Entry<Player, Map<ResourceType, Integer>> entry : playerGains.entrySet()) {
@@ -47,5 +69,16 @@ public class ResourceProduction {
             bank.deduct(resource, needed);
         }
     }
-}
 
+    private void giveRemainingToSinglePlayer(
+            ResourceType resource, int available,
+            Map<Player, Map<ResourceType, Integer>> playerGains,
+            Bank bank) {
+        for (Map.Entry<Player, Map<ResourceType, Integer>> entry : playerGains.entrySet()) {
+            if (entry.getValue().containsKey(resource)) {
+                entry.getKey().addResources(resource, available);
+            }
+        }
+        bank.deduct(resource, available);
+    }
+}

--- a/src/main/java/domain/TerrainType.java
+++ b/src/main/java/domain/TerrainType.java
@@ -4,6 +4,13 @@ public enum TerrainType {
     HILLS, FOREST, MOUNTAINS, FIELDS, PASTURE, DESERT;
 
     public ResourceType getResourceType() {
-        throw new UnsupportedOperationException("Not implemented");
+        switch (this) {
+            case HILLS: return ResourceType.BRICK;
+            case FOREST: return ResourceType.LUMBER;
+            case MOUNTAINS: return ResourceType.ORE;
+            case FIELDS: return ResourceType.GRAIN;
+            case PASTURE: return ResourceType.WOOL;
+            default: throw new IllegalStateException("DESERT does not produce a resource");
+        }
     }
 }

--- a/src/main/java/domain/TerrainType.java
+++ b/src/main/java/domain/TerrainType.java
@@ -1,5 +1,9 @@
 package domain;
 
 public enum TerrainType {
-    HILLS, FOREST, MOUNTAINS, FIELDS, PASTURE, DESERT
+    HILLS, FOREST, MOUNTAINS, FIELDS, PASTURE, DESERT;
+
+    public ResourceType getResourceType() {
+        throw new UnsupportedOperationException("Not implemented");
+    }
 }

--- a/src/main/java/domain/Vertex.java
+++ b/src/main/java/domain/Vertex.java
@@ -69,10 +69,10 @@ public final class Vertex {
     }
 
     public boolean isCity() {
-        throw new UnsupportedOperationException("Not implemented");
+        return city;
     }
 
     public void upgradeToCity() {
-        throw new UnsupportedOperationException("Not implemented");
+        this.city = true;
     }
 }

--- a/src/main/java/domain/Vertex.java
+++ b/src/main/java/domain/Vertex.java
@@ -73,6 +73,9 @@ public final class Vertex {
     }
 
     public void upgradeToCity() {
+        if (!isOccupied()) {
+            throw new IllegalStateException("Cannot upgrade an unoccupied vertex to a city");
+        }
         this.city = true;
     }
 }

--- a/src/main/java/domain/Vertex.java
+++ b/src/main/java/domain/Vertex.java
@@ -10,6 +10,7 @@ public final class Vertex {
 
     private final int id;
     private Player owner = null;
+    private boolean city = false;
     private final List<Hex> adjacentHexes;
     private final List<Vertex> adjacentVertices;
 
@@ -65,5 +66,13 @@ public final class Vertex {
 
     public List<Vertex> getAdjacentVertices() {
         return new ArrayList<>(adjacentVertices);
+    }
+
+    public boolean isCity() {
+        throw new UnsupportedOperationException("Not implemented");
+    }
+
+    public void upgradeToCity() {
+        throw new UnsupportedOperationException("Not implemented");
     }
 }

--- a/src/test/java/domain/BankTest.java
+++ b/src/test/java/domain/BankTest.java
@@ -70,4 +70,11 @@ public class BankTest {
         Bank bank = bankWithBrick(5);
         assertThrows(IllegalArgumentException.class, () -> bank.deduct(ResourceType.BRICK, 6));
     }
+
+    @Test
+    void PackagePrivateConstructor_WithMissingResourceType_ThrowsIllegalArgumentException() {
+        Map<ResourceType, Integer> incomplete = new EnumMap<>(ResourceType.class);
+        incomplete.put(ResourceType.BRICK, 5);
+        assertThrows(IllegalArgumentException.class, () -> new Bank(incomplete));
+    }
 }

--- a/src/test/java/domain/BankTest.java
+++ b/src/test/java/domain/BankTest.java
@@ -1,0 +1,73 @@
+package domain;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.EnumMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class BankTest {
+
+    private Bank bankWithBrick(int amount) {
+        Map<ResourceType, Integer> resources = new EnumMap<>(ResourceType.class);
+        resources.put(ResourceType.BRICK, amount);
+        resources.put(ResourceType.LUMBER, 0);
+        resources.put(ResourceType.ORE, 0);
+        resources.put(ResourceType.GRAIN, 0);
+        resources.put(ResourceType.WOOL, 0);
+        return new Bank(resources);
+    }
+
+    @Test
+    void Constructor_DefaultBank_Has19OfEachResource() {
+        Bank bank = new Bank();
+        for (ResourceType type : ResourceType.values()) {
+            assertEquals(19, bank.getResourceCount(type));
+        }
+    }
+
+    @Test
+    void GetResourceCount_WithNullType_ThrowsIllegalArgumentException() {
+        Bank bank = new Bank();
+        assertThrows(IllegalArgumentException.class, () -> bank.getResourceCount(null));
+    }
+
+    @Test
+    void GetResourceCount_WithValidType_ReturnsCurrentCount() {
+        Bank bank = bankWithBrick(5);
+        assertEquals(5, bank.getResourceCount(ResourceType.BRICK));
+    }
+
+    @Test
+    void Deduct_WithNullType_ThrowsIllegalArgumentException() {
+        Bank bank = new Bank();
+        assertThrows(IllegalArgumentException.class, () -> bank.deduct(null, 1));
+    }
+
+    @Test
+    void Deduct_WithNegativeAmount_ThrowsIllegalArgumentException() {
+        Bank bank = new Bank();
+        assertThrows(IllegalArgumentException.class, () -> bank.deduct(ResourceType.BRICK, -1));
+    }
+
+    @Test
+    void Deduct_WithZeroAmount_NoChange() {
+        Bank bank = bankWithBrick(5);
+        bank.deduct(ResourceType.BRICK, 0);
+        assertEquals(5, bank.getResourceCount(ResourceType.BRICK));
+    }
+
+    @Test
+    void Deduct_ExactlyAvailableAmount_LeavesZero() {
+        Bank bank = bankWithBrick(5);
+        bank.deduct(ResourceType.BRICK, 5);
+        assertEquals(0, bank.getResourceCount(ResourceType.BRICK));
+    }
+
+    @Test
+    void Deduct_OneMoreThanAvailable_ThrowsIllegalArgumentException() {
+        Bank bank = bankWithBrick(5);
+        assertThrows(IllegalArgumentException.class, () -> bank.deduct(ResourceType.BRICK, 6));
+    }
+}

--- a/src/test/java/domain/BoardTest.java
+++ b/src/test/java/domain/BoardTest.java
@@ -291,6 +291,25 @@ public class BoardTest {
     }
 
     @Test
+    void SatisfiesDistanceRule_WhenTargetVertexIsOccupied_ReturnsFalse() {
+        Player player = EasyMock.createMock(Player.class);
+        Vertex vertex = new Vertex(0, new ArrayList<>(), new ArrayList<>());
+        vertex.setOwner(player);
+        assertFalse(board.satisfiesDistanceRule(vertex));
+    }
+
+    @Test
+    void PackagePrivateConstructor_ExternalMutationOfEdgeListDoesNotAffectBoard() {
+        Vertex v1 = new Vertex(0, new ArrayList<>(), new ArrayList<>());
+        Vertex v2 = new Vertex(1, new ArrayList<>(), new ArrayList<>());
+        List<Edge> edges = new ArrayList<>();
+        edges.add(new Edge(0, v1, v2));
+        Board testBoard = new Board(hexes, new ArrayList<>(), edges);
+        edges.clear();
+        assertEquals(1, testBoard.getEdges().size());
+    }
+
+    @Test
     void IsConnectedToPlayer_WhenNoAdjacentRoads_ReturnsFalse() {
         Vertex vertex = new Vertex(0, new ArrayList<>(), new ArrayList<>());
         Vertex other = new Vertex(1, new ArrayList<>(), new ArrayList<>());

--- a/src/test/java/domain/ResourceProductionTest.java
+++ b/src/test/java/domain/ResourceProductionTest.java
@@ -156,4 +156,67 @@ public class ResourceProductionTest {
 
         assertEquals(4, bank.getResourceCount(ResourceType.BRICK));
     }
+
+    @Test
+    void DistributeResources_NullVertices_ThrowsIllegalArgumentException() {
+        Bank bank = new Bank();
+        assertThrows(IllegalArgumentException.class,
+                () -> new ResourceProduction().distributeResources(6, null, bank));
+    }
+
+    @Test
+    void DistributeResources_NullBank_ThrowsIllegalArgumentException() {
+        assertThrows(IllegalArgumentException.class,
+                () -> new ResourceProduction().distributeResources(6, new ArrayList<>(), null));
+    }
+
+    @Test
+    void DistributeResources_SinglePlayer_CityAdjacent_BankHasOneLessThanNeeded_PlayerReceivesWhatRemains() {
+        Player player = new Player("Alice", PlayerColor.RED);
+        Hex hex = new Hex(TerrainType.HILLS, 6);
+        Vertex vertex = cityVertex(0, player, List.of(hex));
+        Bank bank = bankWith(ResourceType.BRICK, 1);
+
+        new ResourceProduction().distributeResources(6, List.of(vertex), bank);
+
+        assertEquals(1, player.getResourceCount(ResourceType.BRICK));
+        assertEquals(0, bank.getResourceCount(ResourceType.BRICK));
+    }
+
+    @Test
+    void DistributeResources_TwoPlayers_BankHasExactAmountNeededForBoth_BothReceive() {
+        Hex hex = new Hex(TerrainType.HILLS, 8);
+        Player alice = new Player("Alice", PlayerColor.RED);
+        Player bob = new Player("Bob", PlayerColor.BLUE);
+        Vertex v1 = settledVertex(0, alice, List.of(hex));
+        Vertex v2 = settledVertex(1, bob, List.of(hex));
+        Bank bank = bankWith(ResourceType.BRICK, 2);
+
+        new ResourceProduction().distributeResources(8, List.of(v1, v2), bank);
+
+        assertEquals(1, alice.getResourceCount(ResourceType.BRICK));
+        assertEquals(1, bob.getResourceCount(ResourceType.BRICK));
+    }
+
+    @Test
+    void DistributeResources_TwoPlayersNeedingDifferentResources_BankShortForOne_AffectedPlayerReceivesWhatRemains() {
+        Hex hillsHex = new Hex(TerrainType.HILLS, 6);
+        Hex mountainsHex = new Hex(TerrainType.MOUNTAINS, 6);
+        Player alice = new Player("Alice", PlayerColor.RED);
+        Player bob = new Player("Bob", PlayerColor.BLUE);
+        Vertex aliceVertex = cityVertex(0, alice, List.of(hillsHex));
+        Vertex bobVertex = settledVertex(1, bob, List.of(mountainsHex));
+        Map<ResourceType, Integer> amounts = new EnumMap<>(ResourceType.class);
+        for (ResourceType t : ResourceType.values()) {
+            amounts.put(t, 0);
+        }
+        amounts.put(ResourceType.BRICK, 1);
+        amounts.put(ResourceType.ORE, 19);
+        Bank bank = new Bank(amounts);
+
+        new ResourceProduction().distributeResources(6, List.of(aliceVertex, bobVertex), bank);
+
+        assertEquals(1, alice.getResourceCount(ResourceType.BRICK));
+        assertEquals(1, bob.getResourceCount(ResourceType.ORE));
+    }
 }

--- a/src/test/java/domain/ResourceProductionTest.java
+++ b/src/test/java/domain/ResourceProductionTest.java
@@ -132,4 +132,28 @@ public class ResourceProductionTest {
         assertEquals(0, alice.getResourceCount(ResourceType.BRICK));
         assertEquals(0, bob.getResourceCount(ResourceType.BRICK));
     }
+
+    @Test
+    void DistributeResources_BankHasExactlyEnough_ResourceDistributed() {
+        Player player = new Player("Alice", PlayerColor.RED);
+        Hex hex = new Hex(TerrainType.HILLS, 6);
+        Vertex vertex = settledVertex(0, player, List.of(hex));
+        Bank bank = bankWith(ResourceType.BRICK, 1);
+
+        new ResourceProduction().distributeResources(6, List.of(vertex), bank);
+
+        assertEquals(1, player.getResourceCount(ResourceType.BRICK));
+    }
+
+    @Test
+    void DistributeResources_BankDeductedAfterDistribution() {
+        Player player = new Player("Alice", PlayerColor.RED);
+        Hex hex = new Hex(TerrainType.HILLS, 6);
+        Vertex vertex = settledVertex(0, player, List.of(hex));
+        Bank bank = bankWith(ResourceType.BRICK, 5);
+
+        new ResourceProduction().distributeResources(6, List.of(vertex), bank);
+
+        assertEquals(4, bank.getResourceCount(ResourceType.BRICK));
+    }
 }

--- a/src/test/java/domain/ResourceProductionTest.java
+++ b/src/test/java/domain/ResourceProductionTest.java
@@ -1,0 +1,135 @@
+package domain;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class ResourceProductionTest {
+
+    private Bank bankWith(ResourceType type, int amount) {
+        Map<ResourceType, Integer> resources = new EnumMap<>(ResourceType.class);
+        for (ResourceType t : ResourceType.values()) {
+            resources.put(t, 0);
+        }
+        resources.put(type, amount);
+        return new Bank(resources);
+    }
+
+    private Vertex settledVertex(int id, Player owner, List<Hex> hexes) {
+        Vertex vertex = new Vertex(id, hexes, new ArrayList<>());
+        vertex.setOwner(owner);
+        return vertex;
+    }
+
+    private Vertex cityVertex(int id, Player owner, List<Hex> hexes) {
+        Vertex vertex = settledVertex(id, owner, hexes);
+        vertex.upgradeToCity();
+        return vertex;
+    }
+
+    @Test
+    void DistributeResources_RollOf7_NoResourcesDistributed() {
+        Player player = new Player("Alice", PlayerColor.RED);
+        Hex hex = new Hex(TerrainType.HILLS, 6);
+        Vertex vertex = settledVertex(0, player, List.of(hex));
+        Bank bank = new Bank();
+
+        new ResourceProduction().distributeResources(7, List.of(vertex), bank);
+
+        assertEquals(0, player.getResourceCount(ResourceType.BRICK));
+    }
+
+    @Test
+    void DistributeResources_RollOf2_SettlementAdjacent_PlayerReceives1() {
+        Player player = new Player("Alice", PlayerColor.RED);
+        Hex hex = new Hex(TerrainType.HILLS, 2);
+        Vertex vertex = settledVertex(0, player, List.of(hex));
+        Bank bank = bankWith(ResourceType.BRICK, 19);
+
+        new ResourceProduction().distributeResources(2, List.of(vertex), bank);
+
+        assertEquals(1, player.getResourceCount(ResourceType.BRICK));
+    }
+
+    @Test
+    void DistributeResources_RollOf12_SettlementAdjacent_PlayerReceives1() {
+        Player player = new Player("Alice", PlayerColor.RED);
+        Hex hex = new Hex(TerrainType.FIELDS, 12);
+        Vertex vertex = settledVertex(0, player, List.of(hex));
+        Bank bank = bankWith(ResourceType.GRAIN, 19);
+
+        new ResourceProduction().distributeResources(12, List.of(vertex), bank);
+
+        assertEquals(1, player.getResourceCount(ResourceType.GRAIN));
+    }
+
+    @Test
+    void DistributeResources_CityAdjacent_PlayerReceives2() {
+        Player player = new Player("Alice", PlayerColor.RED);
+        Hex hex = new Hex(TerrainType.HILLS, 6);
+        Vertex vertex = cityVertex(0, player, List.of(hex));
+        Bank bank = bankWith(ResourceType.BRICK, 19);
+
+        new ResourceProduction().distributeResources(6, List.of(vertex), bank);
+
+        assertEquals(2, player.getResourceCount(ResourceType.BRICK));
+    }
+
+    @Test
+    void DistributeResources_BankHas0_NoOneReceives() {
+        Player player = new Player("Alice", PlayerColor.RED);
+        Hex hex = new Hex(TerrainType.HILLS, 6);
+        Vertex vertex = settledVertex(0, player, List.of(hex));
+        Bank bank = bankWith(ResourceType.BRICK, 0);
+
+        new ResourceProduction().distributeResources(6, List.of(vertex), bank);
+
+        assertEquals(0, player.getResourceCount(ResourceType.BRICK));
+    }
+
+    @Test
+    void DistributeResources_UnoccupiedVertexAdjacent_NoResourceDistributed() {
+        Hex hex = new Hex(TerrainType.HILLS, 4);
+        Vertex vertex = new Vertex(0, List.of(hex), new ArrayList<>());
+        Bank bank = bankWith(ResourceType.BRICK, 19);
+
+        new ResourceProduction().distributeResources(4, List.of(vertex), bank);
+
+        assertEquals(19, bank.getResourceCount(ResourceType.BRICK));
+    }
+
+    @Test
+    void DistributeResources_MultiplePlayersAdjacentSameHex_AllReceive() {
+        Hex hex = new Hex(TerrainType.HILLS, 8);
+        Player alice = new Player("Alice", PlayerColor.RED);
+        Player bob = new Player("Bob", PlayerColor.BLUE);
+        Vertex v1 = settledVertex(0, alice, List.of(hex));
+        Vertex v2 = settledVertex(1, bob, List.of(hex));
+        Bank bank = bankWith(ResourceType.BRICK, 19);
+
+        new ResourceProduction().distributeResources(8, List.of(v1, v2), bank);
+
+        assertEquals(1, alice.getResourceCount(ResourceType.BRICK));
+        assertEquals(1, bob.getResourceCount(ResourceType.BRICK));
+    }
+
+    @Test
+    void DistributeResources_BankCannotCoverAll_NobodyReceives() {
+        Hex hex = new Hex(TerrainType.HILLS, 8);
+        Player alice = new Player("Alice", PlayerColor.RED);
+        Player bob = new Player("Bob", PlayerColor.BLUE);
+        Vertex v1 = settledVertex(0, alice, List.of(hex));
+        Vertex v2 = settledVertex(1, bob, List.of(hex));
+        Bank bank = bankWith(ResourceType.BRICK, 1);
+
+        new ResourceProduction().distributeResources(8, List.of(v1, v2), bank);
+
+        assertEquals(0, alice.getResourceCount(ResourceType.BRICK));
+        assertEquals(0, bob.getResourceCount(ResourceType.BRICK));
+    }
+}

--- a/src/test/java/domain/TerrainTypeTest.java
+++ b/src/test/java/domain/TerrainTypeTest.java
@@ -1,0 +1,38 @@
+package domain;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class TerrainTypeTest {
+
+    @Test
+    void GetResourceType_ForHills_ReturnsBrick() {
+        assertEquals(ResourceType.BRICK, TerrainType.HILLS.getResourceType());
+    }
+
+    @Test
+    void GetResourceType_ForForest_ReturnsLumber() {
+        assertEquals(ResourceType.LUMBER, TerrainType.FOREST.getResourceType());
+    }
+
+    @Test
+    void GetResourceType_ForMountains_ReturnsOre() {
+        assertEquals(ResourceType.ORE, TerrainType.MOUNTAINS.getResourceType());
+    }
+
+    @Test
+    void GetResourceType_ForFields_ReturnsGrain() {
+        assertEquals(ResourceType.GRAIN, TerrainType.FIELDS.getResourceType());
+    }
+
+    @Test
+    void GetResourceType_ForPasture_ReturnsWool() {
+        assertEquals(ResourceType.WOOL, TerrainType.PASTURE.getResourceType());
+    }
+
+    @Test
+    void GetResourceType_ForDesert_ThrowsIllegalStateException() {
+        assertThrows(IllegalStateException.class, () -> TerrainType.DESERT.getResourceType());
+    }
+}

--- a/src/test/java/domain/VertexTest.java
+++ b/src/test/java/domain/VertexTest.java
@@ -97,4 +97,27 @@ public class VertexTest {
         Vertex vertex = new Vertex(0, new ArrayList<>(), adjacentVertices);
         assertEquals(adjacentVertices, vertex.getAdjacentVertices());
     }
+
+    @Test
+    void IsCity_WhenNoOwner_ReturnsFalse() {
+        Vertex vertex = new Vertex(0, new ArrayList<>(), new ArrayList<>());
+        assertFalse(vertex.isCity());
+    }
+
+    @Test
+    void IsCity_WhenOwnerSetButNotUpgraded_ReturnsFalse() {
+        Vertex vertex = new Vertex(0, new ArrayList<>(), new ArrayList<>());
+        Player player = EasyMock.createMock(Player.class);
+        vertex.setOwner(player);
+        assertFalse(vertex.isCity());
+    }
+
+    @Test
+    void IsCity_AfterUpgradeToCity_ReturnsTrue() {
+        Vertex vertex = new Vertex(0, new ArrayList<>(), new ArrayList<>());
+        Player player = EasyMock.createMock(Player.class);
+        vertex.setOwner(player);
+        vertex.upgradeToCity();
+        assertTrue(vertex.isCity());
+    }
 }

--- a/src/test/java/domain/VertexTest.java
+++ b/src/test/java/domain/VertexTest.java
@@ -120,4 +120,10 @@ public class VertexTest {
         vertex.upgradeToCity();
         assertTrue(vertex.isCity());
     }
+
+    @Test
+    void UpgradeToCity_WhenVertexIsUnoccupied_ThrowsIllegalStateException() {
+        Vertex vertex = new Vertex(0, new ArrayList<>(), new ArrayList<>());
+        assertThrows(IllegalStateException.class, vertex::upgradeToCity);
+    }
 }


### PR DESCRIPTION
- Adds isCity() and upgradeToCity() to Vertex to distinguish settlements (1 resource) from cities (2 resources)
- Adds getResourceType() to TerrainType to map each terrain to its corresponding resource
- Implements new Bank class to track resource supply (19 of each by default) with all-or-nothing distribution enforcement
- Implements ResourceProduction class with distributeResources(int roll, List<Vertex> vertices, Bank bank), skips roll of 7, distributes to all adjacent occupied vertices, enforces bank shortage rule per resource type

Closes #46