### PR TITLE
implement development cards

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,8 +10,8 @@ plugins {
 // Add new classes here as they are implemented and tested.
 pitest {
     junit5PluginVersion = "1.2.1"
-    targetClasses = setOf("domain.*")
-    targetTests = setOf("domain.*")
+    targetClasses = setOf("domain.Board", "domain.Edge", "domain.Vertex", "domain.DiceRoll", "domain.Bank", "domain.DevelopmentCard")
+    targetTests = setOf("domain.BoardTest", "domain.EdgeTest", "domain.VertexTest", "domain.DiceRollTest", "domain.BankTest", "domain.DevelopmentCardTest")
     outputFormats = setOf("HTML")
     mutationThreshold = 100
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,8 +10,8 @@ plugins {
 // Add new classes here as they are implemented and tested.
 pitest {
     junit5PluginVersion = "1.2.1"
-    targetClasses = setOf("domain.Board", "domain.Edge", "domain.Vertex", "domain.DiceRoll", "domain.TerrainType", "domain.Bank", "domain.ResourceProduction")
-    targetTests = setOf("domain.BoardTest", "domain.EdgeTest", "domain.VertexTest", "domain.DiceRollTest", "domain.TerrainTypeTest", "domain.BankTest", "domain.ResourceProductionTest")
+    targetClasses = setOf("domain.*")
+    targetTests = setOf("domain.*")
     outputFormats = setOf("HTML")
     mutationThreshold = 100
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,8 +10,8 @@ plugins {
 // Add new classes here as they are implemented and tested.
 pitest {
     junit5PluginVersion = "1.2.1"
-    targetClasses = setOf("domain.Board", "domain.Edge", "domain.Vertex", "domain.DiceRoll", "domain.Bank", "domain.DevelopmentCard")
-    targetTests = setOf("domain.BoardTest", "domain.EdgeTest", "domain.VertexTest", "domain.DiceRollTest", "domain.BankTest", "domain.DevelopmentCardTest")
+    targetClasses = setOf("domain.Board", "domain.Edge", "domain.Vertex", "domain.DiceRoll", "domain.TerrainType", "domain.Bank", "domain.ResourceProduction", "domain.DevelopmentCard")
+    targetTests = setOf("domain.BoardTest", "domain.EdgeTest", "domain.VertexTest", "domain.DiceRollTest", "domain.TerrainTypeTest", "domain.BankTest", "domain.ResourceProductionTest", "domain.DevelopmentCardTest")
     outputFormats = setOf("HTML")
     mutationThreshold = 100
 }

--- a/docs/bva/DevelopmentCard.md
+++ b/docs/bva/DevelopmentCard.md
@@ -1,0 +1,17 @@
+# BVA Analysis for DevelopmentCard
+
+## Method under test: `DevelopmentCard(DevelopmentCardType type)`
+
+**Step 4: Test Cases (Each-Choice)**
+
+- **TC1: Constructor_WithNullType_ThrowsIllegalArgumentException** ( not implemented )
+    - State of the system: `type = null`
+    - Expected output: `IllegalArgumentException`
+
+- **TC2: Constructor_WithValidType_NoExceptionThrown** ( not implemented )
+    - State of the system: `type = KNIGHT`
+    - Expected output: no exception thrown
+
+- **TC3: Constructor_NewCard_IsNotPlayed** ( not implemented )
+    - State of the system: `type = KNIGHT`
+    - Expected output: `isPlayed()` returns `false`

--- a/docs/bva/DevelopmentCard.md
+++ b/docs/bva/DevelopmentCard.md
@@ -2,8 +2,6 @@
 
 ## Method under test: `DevelopmentCard(DevelopmentCardType type)`
 
-**Step 4: Test Cases (Each-Choice)**
-
 - **TC1: Constructor_WithNullType_ThrowsIllegalArgumentException** ( not implemented )
     - State of the system: `type = null`
     - Expected output: `IllegalArgumentException`
@@ -15,3 +13,9 @@
 - **TC3: Constructor_NewCard_IsNotPlayed** ( not implemented )
     - State of the system: `type = KNIGHT`
     - Expected output: `isPlayed()` returns `false`
+
+## Method under test: `getType()`
+
+- **TC4: GetType_ReturnsCorrectType** ( not implemented )
+    - State of the system: `DevelopmentCard(ROAD_BUILDING)`
+    - Expected output: `ROAD_BUILDING`

--- a/docs/bva/DevelopmentCard.md
+++ b/docs/bva/DevelopmentCard.md
@@ -29,3 +29,13 @@
 - **TC6: IsPlayed_AfterMarkAsPlayed_ReturnsTrue** ( not implemented )
     - State of the system: `DevelopmentCard(YEAR_OF_PLENTY)`, `markAsPlayed()` called once
     - Expected output: `true`
+
+## Method under test: `markAsPlayed()`
+
+- **TC7: MarkAsPlayed_OnUnplayedCard_NoExceptionThrown** ( not implemented )
+    - State of the system: `DevelopmentCard(MONOPOLY)`, card not yet played
+    - Expected output: no exception thrown
+
+- **TC8: MarkAsPlayed_OnAlreadyPlayedCard_ThrowsIllegalStateException** ( not implemented )
+    - State of the system: `DevelopmentCard(MONOPOLY)`, `markAsPlayed()` already called once
+    - Expected output: `IllegalStateException`

--- a/docs/bva/DevelopmentCard.md
+++ b/docs/bva/DevelopmentCard.md
@@ -19,3 +19,13 @@
 - **TC4: GetType_ReturnsCorrectType** ( not implemented )
     - State of the system: `DevelopmentCard(ROAD_BUILDING)`
     - Expected output: `ROAD_BUILDING`
+
+## Method under test: `isPlayed()`
+
+- **TC5: IsPlayed_WhenNewCard_ReturnsFalse** ( not implemented )
+    - State of the system: `DevelopmentCard(YEAR_OF_PLENTY)`, `markAsPlayed()` not yet called
+    - Expected output: `false`
+
+- **TC6: IsPlayed_AfterMarkAsPlayed_ReturnsTrue** ( not implemented )
+    - State of the system: `DevelopmentCard(YEAR_OF_PLENTY)`, `markAsPlayed()` called once
+    - Expected output: `true`

--- a/docs/bva/DevelopmentCard.md
+++ b/docs/bva/DevelopmentCard.md
@@ -2,36 +2,36 @@
 
 ## Method under test: `DevelopmentCard(DevelopmentCardType type)`
 
-- **TC1: Constructor_WithNullType_ThrowsIllegalArgumentException** ( not implemented )
+- **TC1: Constructor_WithNullType_ThrowsIllegalArgumentException** ( implemented )
     - State of the system: `type = null`
     - Expected output: `IllegalArgumentException`
 
-- **TC2: Constructor_WithValidType_NoExceptionThrown** ( not implemented )
+- **TC2: Constructor_WithValidType_NoExceptionThrown** ( implemented )
     - State of the system: `type = KNIGHT`
     - Expected output: no exception thrown
 
 ## Method under test: `getType()`
 
-- **TC3: GetType_ReturnsCorrectType** ( not implemented )
+- **TC3: GetType_ReturnsCorrectType** ( implemented )
     - State of the system: `DevelopmentCard(ROAD_BUILDING)`
     - Expected output: `ROAD_BUILDING`
 
 ## Method under test: `isPlayed()`
 
-- **TC4: IsPlayed_WhenNewCard_ReturnsFalse** ( not implemented )
+- **TC4: IsPlayed_WhenNewCard_ReturnsFalse** ( implemented )
     - State of the system: `DevelopmentCard(YEAR_OF_PLENTY)`, `markAsPlayed()` not yet called
     - Expected output: `false`
 
-- **TC5: IsPlayed_AfterMarkAsPlayed_ReturnsTrue** ( not implemented )
+- **TC5: IsPlayed_AfterMarkAsPlayed_ReturnsTrue** ( implemented )
     - State of the system: `DevelopmentCard(YEAR_OF_PLENTY)`, `markAsPlayed()` called once
     - Expected output: `true`
 
 ## Method under test: `markAsPlayed()`
 
-- **TC6: MarkAsPlayed_OnUnplayedCard_NoExceptionThrown** ( not implemented )
+- **TC6: MarkAsPlayed_OnUnplayedCard_NoExceptionThrown** ( implemented )
     - State of the system: `DevelopmentCard(MONOPOLY)`, card not yet played
     - Expected output: no exception thrown
 
-- **TC7: MarkAsPlayed_OnAlreadyPlayedCard_ThrowsIllegalStateException** ( not implemented )
+- **TC7: MarkAsPlayed_OnAlreadyPlayedCard_ThrowsIllegalStateException** ( implemented )
     - State of the system: `DevelopmentCard(MONOPOLY)`, `markAsPlayed()` already called once
     - Expected output: `IllegalStateException`

--- a/docs/bva/DevelopmentCard.md
+++ b/docs/bva/DevelopmentCard.md
@@ -35,3 +35,7 @@
 - **TC7: MarkAsPlayed_OnAlreadyPlayedCard_ThrowsIllegalStateException** ( implemented )
     - State of the system: `DevelopmentCard(MONOPOLY)`, `markAsPlayed()` already called once
     - Expected output: `IllegalStateException`
+
+- **TC8: MarkAsPlayed_OnVictoryPointCard_ThrowsIllegalStateException** ( implemented )
+  - State of the system: `DevelopmentCard(VICTORY_POINT)`, `markAsPlayed()` called
+  - Expected output: `IllegalStateException`

--- a/docs/bva/DevelopmentCard.md
+++ b/docs/bva/DevelopmentCard.md
@@ -10,32 +10,28 @@
     - State of the system: `type = KNIGHT`
     - Expected output: no exception thrown
 
-- **TC3: Constructor_NewCard_IsNotPlayed** ( not implemented )
-    - State of the system: `type = KNIGHT`
-    - Expected output: `isPlayed()` returns `false`
-
 ## Method under test: `getType()`
 
-- **TC4: GetType_ReturnsCorrectType** ( not implemented )
+- **TC3: GetType_ReturnsCorrectType** ( not implemented )
     - State of the system: `DevelopmentCard(ROAD_BUILDING)`
     - Expected output: `ROAD_BUILDING`
 
 ## Method under test: `isPlayed()`
 
-- **TC5: IsPlayed_WhenNewCard_ReturnsFalse** ( not implemented )
+- **TC4: IsPlayed_WhenNewCard_ReturnsFalse** ( not implemented )
     - State of the system: `DevelopmentCard(YEAR_OF_PLENTY)`, `markAsPlayed()` not yet called
     - Expected output: `false`
 
-- **TC6: IsPlayed_AfterMarkAsPlayed_ReturnsTrue** ( not implemented )
+- **TC5: IsPlayed_AfterMarkAsPlayed_ReturnsTrue** ( not implemented )
     - State of the system: `DevelopmentCard(YEAR_OF_PLENTY)`, `markAsPlayed()` called once
     - Expected output: `true`
 
 ## Method under test: `markAsPlayed()`
 
-- **TC7: MarkAsPlayed_OnUnplayedCard_NoExceptionThrown** ( not implemented )
+- **TC6: MarkAsPlayed_OnUnplayedCard_NoExceptionThrown** ( not implemented )
     - State of the system: `DevelopmentCard(MONOPOLY)`, card not yet played
     - Expected output: no exception thrown
 
-- **TC8: MarkAsPlayed_OnAlreadyPlayedCard_ThrowsIllegalStateException** ( not implemented )
+- **TC7: MarkAsPlayed_OnAlreadyPlayedCard_ThrowsIllegalStateException** ( not implemented )
     - State of the system: `DevelopmentCard(MONOPOLY)`, `markAsPlayed()` already called once
     - Expected output: `IllegalStateException`

--- a/docs/design/game-first-turn-design.md
+++ b/docs/design/game-first-turn-design.md
@@ -128,7 +128,6 @@ Represents a single development card. Tracks its type and whether it has been pl
 | `getType()`                     | `DevelopmentCardType` | Returns the card type                                                                             |
 | `isPlayed()`                    | `boolean`             | Returns true if the card has been played                                                          |
 | `markAsPlayed()`                | `void`                | Marks the card as played; throws `IllegalStateException` if already played                        |
-| `isVictoryPoint()`              | `boolean`             | Returns true if the card type is `VICTORY_POINT`                                                  |
 
 **Invariants:**
 - Once `markAsPlayed()` is called, `isPlayed()` always returns true

--- a/docs/design/game-first-turn-design.md
+++ b/docs/design/game-first-turn-design.md
@@ -15,7 +15,7 @@ TurnPhase (enum)
 DiceRoll ──────────────────► (no domain dependencies; pure randomness)
 Bank ──────────────────────► ResourceType
 TradeOffer ────────────────► Player, ResourceType
-Turn ──────────────────────► Game, DiceRoll, Bank, TradeOffer, Vertex, Edge, TurnPhase
+Turn ──────────────────────► Game, DiceRoll, Bank, TradeOffer, Vertex, Edge, TurnPhase, DevelopmentCard
 ```
 
 ---
@@ -29,6 +29,13 @@ PRODUCTION, TRADE, BUILD, DONE
 Represents the current phase within an active turn. Phases advance in order and may not be skipped or reversed.
 
 ---
+
+### `DevelopmentCardType`
+```
+KNIGHT, ROAD_BUILDING, YEAR_OF_PLENTY, MONOPOLY, VICTORY_POINT
+```
+Represents the type of a development card. There are 25 total: 14 Knight, 6 Progress (Road Building, Year of Plenty, Monopoly), and 5 Victory Point.
+
 
 ## Classes
 
@@ -107,42 +114,68 @@ PENDING, ACCEPTED, REJECTED
 
 ---
 
+### `DevelopmentCard`
+Represents a single development card. Tracks its type and whether it has been played.
 
+| Field        | Type                  | Description                                      |
+|--------------|-----------------------|--------------------------------------------------|
+| `type`       | `DevelopmentCardType` | The type of this card                            |
+| `played`     | `boolean`             | True if this card has already been played        |
 
+| Method                          | Return Type           | Description                                                                                       |
+|---------------------------------|-----------------------|---------------------------------------------------------------------------------------------------|
+| `DevelopmentCard(DevelopmentCardType type)` | —       | Constructor; throws `IllegalArgumentException` if type is null                                    |
+| `getType()`                     | `DevelopmentCardType` | Returns the card type                                                                             |
+| `isPlayed()`                    | `boolean`             | Returns true if the card has been played                                                          |
+| `markAsPlayed()`                | `void`                | Marks the card as played; throws `IllegalStateException` if already played                        |
+| `isVictoryPoint()`              | `boolean`             | Returns true if the card type is `VICTORY_POINT`                                                  |
+
+**Invariants:**
+- Once `markAsPlayed()` is called, `isPlayed()` always returns true
+- Victory Point cards are never marked as played until the player declares victory
+
+---
+
+### `Turn`
 Orchestrates a single player's turn through its three phases. Enforces phase order, handles the robber on a 7, and delegates building cost validation to the existing domain objects.
 
-| Field                  | Type          | Description                                                                    |
-|------------------------|---------------|--------------------------------------------------------------------------------|
-| `game`                 | `Game`        | The current game state                                                         |
-| `activePlayer`         | `Player`      | The player taking this turn                                                    |
-| `dice`                 | `DiceRoll`    | The dice used for resource production                                          |
-| `bank`                 | `Bank`        | The shared resource bank                                                       |
-| `phase`                | `TurnPhase`   | The current phase of this turn                                                 |
-| `rolledThisTurn`       | `boolean`     | True once `rollDice()` has been called                                         |
-| `playedDevCardThisTurn`| `boolean`     | True if a development card has already been played this turn                   |
-| `pendingTrade`         | `TradeOffer`  | The active domestic trade offer, if any; null when no offer is pending         |
+| Field                   | Type                                 | Description                                                            |
+|-------------------------|--------------------------------------|------------------------------------------------------------------------|
+| `game`                  | `Game`                               | The current game state                                                 |
+| `activePlayer`          | `Player`                             | The player taking this turn                                            |
+| `dice`                  | `DiceRoll`                           | The dice used for resource production                                  |
+| `bank`                  | `Bank`                               | The shared resource bank                                               |
+| `phase`                 | `TurnPhase`                          | The current phase of this turn                                         |
+| `rolledThisTurn`        | `boolean`                            | True once `rollDice()` has been called                                 |
+| `playedDevCardThisTurn` | `boolean`                            | True if a development card has already been played this turn           |
+| `pendingTrade`          | `TradeOffer`                         | The active domestic trade offer, if any; null when no offer is pending |
+| `developmentDeck`       | `List<DevelopmentCard>`              | The shuffled deck of development cards available to buy                |
+| `playerHands`           | `Map<Player, List<DevelopmentCard>>` | Each player's hand of development cards                                |
 
-| Method                                                      | Return Type | Description                                                                                                                                                              |
-|-------------------------------------------------------------|-------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `Turn(Game game, Player activePlayer, DiceRoll dice, Bank bank)`| —           | Constructor; validates no argument is null, sets `phase` to `PRODUCTION`                                                                                                |
-| `getActivePlayer()`                                         | `Player`    | Returns the player whose turn this is                                                                                                                                    |
-| `getPhase()`                                               | `TurnPhase` | Returns the current phase                                                                                                                                                |
-| `rollDice()`                                               | `int`       | Calls `dice.roll()`, advances to `TRADE` phase, triggers production or robber logic; throws `IllegalStateException` if called outside `PRODUCTION` phase or called twice |
-| `produceResources(int roll)`                               | `void`      | Distributes resources to all players for the rolled number per settlement/city adjacency; respects bank supply limits and the robber's blocked hex; called internally by `rollDice()` |
-| `advanceToTrade()`                                         | `void`      | Internal; sets `phase` to `TRADE` after production resolves                                                                                                             |
-| `advanceToBuild()`                                         | `void`      | Called by the active player when done trading; sets `phase` to `BUILD`; throws `IllegalStateException` if not in `TRADE` phase                                          |
-| `endTurn()`                                               | `void`      | Sets `phase` to `DONE`; throws `IllegalStateException` if not in `BUILD` phase                                                                                          |
-| `buildRoad(int edgeId)`                                   | `void`      | Validates player can afford a road (1 Brick + 1 Lumber), that the edge is unoccupied and connected to their network, deducts cost; throws if invalid                   |
-| `buildSettlement(int vertexId)`                           | `void`      | Validates player can afford a settlement (1 Brick + 1 Lumber + 1 Wool + 1 Grain), Distance Rule, and road connection; deducts cost; throws if invalid                  |
-| `buildCity(int vertexId)`                                 | `void`      | Validates player can afford a city (3 Ore + 2 Grain) and that the vertex has an existing settlement owned by the player; replaces settlement; throws if invalid         |
-| `buyDevelopmentCard()`                                    | `void`      | Validates player can afford (1 Ore + 1 Wool + 1 Grain) and that development cards remain; deducts cost; throws if invalid                                               |
-| `isSevenRolled()`                                         | `boolean`   | Returns true if the roll this turn was a 7                                                                                                                               |
-| `proposeTrade(Player recipient, Map<ResourceType, Integer> offering, Map<ResourceType, Integer> requesting)` | `TradeOffer` | Creates and stores a `TradeOffer`; throws `IllegalStateException` if not in `TRADE` phase or if a trade is already pending; throws `IllegalArgumentException` if the active player cannot afford the offering |
-| `acceptTrade(TradeOffer offer)`                           | `void`      | Called by the recipient to accept; validates the recipient can afford `requesting`, then executes the exchange between both players via their `addResources` / resource deduction; throws if offer is not pending or either player lacks cards |
-| `rejectTrade(TradeOffer offer)`                           | `void`      | Called by the recipient to reject; marks the offer as `REJECTED` and clears `pendingTrade`; throws if offer is not pending                                              |
-| `executeMaritimeTrade(ResourceType giving, int amount, ResourceType receiving)` | `void` | Performs a maritime trade at the active player's best available rate (4:1 default, 3:1 with a generic harbor, 2:1 with a matching special harbor); validates rate and bank supply; throws if not in `TRADE` phase or player cannot afford it |
-| `getMaritimeRate(ResourceType)`                           | `int`       | Returns the best maritime trade rate available to the active player for the given resource (2, 3, or 4), based on adjacent harbor vertices                              |
-| `getPendingTrade()`                                       | `Optional<TradeOffer>` | Returns the current pending trade offer, or `Optional.empty()` if none                                                                                    |
+| Method                                                                                                       | Return Type             | Description                                                                                                                                                                                                                                                            |
+|--------------------------------------------------------------------------------------------------------------|-------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `Turn(Game game, Player activePlayer, DiceRoll dice, Bank bank)`                                             | —                       | Constructor; validates no argument is null, sets `phase` to `PRODUCTION`, initializes developmentDeck with 25 shuffled cards (14 KNIGHT, 6 Progress, 5 VICTORY_POINT) and empty hands for all players in the game                                                      |
+| `getActivePlayer()`                                                                                          | `Player`                | Returns the player whose turn this is                                                                                                                                                                                                                                  |
+| `getPhase()`                                                                                                 | `TurnPhase`             | Returns the current phase                                                                                                                                                                                                                                              |
+| `rollDice()`                                                                                                 | `int`                   | Calls `dice.roll()`, advances to `TRADE` phase, triggers production or robber logic; throws `IllegalStateException` if called outside `PRODUCTION` phase or called twice                                                                                               |
+| `produceResources(int roll)`                                                                                 | `void`                  | Distributes resources to all players for the rolled number per settlement/city adjacency; respects bank supply limits and the robber's blocked hex; called internally by `rollDice()`                                                                                  |
+| `advanceToTrade()`                                                                                           | `void`                  | Internal; sets `phase` to `TRADE` after production resolves                                                                                                                                                                                                            |
+| `advanceToBuild()`                                                                                           | `void`                  | Called by the active player when done trading; sets `phase` to `BUILD`; throws `IllegalStateException` if not in `TRADE` phase                                                                                                                                         |
+| `endTurn()`                                                                                                  | `void`                  | Sets `phase` to `DONE`; throws `IllegalStateException` if not in `BUILD` phase                                                                                                                                                                                         |
+| `buildRoad(int edgeId)`                                                                                      | `void`                  | Validates player can afford a road (1 Brick + 1 Lumber), that the edge is unoccupied and connected to their network, deducts cost; throws if invalid                                                                                                                   |
+| `buildSettlement(int vertexId)`                                                                              | `void`                  | Validates player can afford a settlement (1 Brick + 1 Lumber + 1 Wool + 1 Grain), Distance Rule, and road connection; deducts cost; throws if invalid                                                                                                                  |
+| `buildCity(int vertexId)`                                                                                    | `void`                  | Validates player can afford a city (3 Ore + 2 Grain) and that the vertex has an existing settlement owned by the player; replaces settlement; throws if invalid                                                                                                        |
+| `buyDevelopmentCard()`                                                                                       | `void`                  | Validates player can afford (1 Ore + 1 Wool + 1 Grain) and that development cards remain; deducts cost; throws if invalid                                                                                                                                              |
+| `isSevenRolled()`                                                                                            | `boolean`               | Returns true if the roll this turn was a 7                                                                                                                                                                                                                             |
+| `proposeTrade(Player recipient, Map<ResourceType, Integer> offering, Map<ResourceType, Integer> requesting)` | `TradeOffer`            | Creates and stores a `TradeOffer`; throws `IllegalStateException` if not in `TRADE` phase or if a trade is already pending; throws `IllegalArgumentException` if the active player cannot afford the offering                                                          |
+| `acceptTrade(TradeOffer offer)`                                                                              | `void`                  | Called by the recipient to accept; validates the recipient can afford `requesting`, then executes the exchange between both players via their `addResources` / resource deduction; throws if offer is not pending or either player lacks cards                         |
+| `rejectTrade(TradeOffer offer)`                                                                              | `void`                  | Called by the recipient to reject; marks the offer as `REJECTED` and clears `pendingTrade`; throws if offer is not pending                                                                                                                                             |
+| `executeMaritimeTrade(ResourceType giving, int amount, ResourceType receiving)`                              | `void`                  | Performs a maritime trade at the active player's best available rate (4:1 default, 3:1 with a generic harbor, 2:1 with a matching special harbor); validates rate and bank supply; throws if not in `TRADE` phase or player cannot afford it                           |
+| `getMaritimeRate(ResourceType)`                                                                              | `int`                   | Returns the best maritime trade rate available to the active player for the given resource (2, 3, or 4), based on adjacent harbor vertices                                                                                                                             |
+| `getPendingTrade()`                                                                                          | `Optional<TradeOffer>`  | Returns the current pending trade offer, or `Optional.empty()` if none                                                                                                                                                                                                 |
+| `playDevelopmentCard(Player player, DevelopmentCard card)`                                                   | `void`                  | Plays a development card for the active player; throws `IllegalStateException` if not in `TRADE` or `BUILD` phase, if a dev card has already been played this turn, if the card was purchased this turn (except Victory Point cards), or if the card is already played |
+| `getPlayerHand(Player player)`                                                                               | `List<DevelopmentCard>` | Returns an unmodifiable view of the player's development card hand                                                                                                                                                                                                     |
+| `getRemainingDeckSize()`                                                                                     | `int`                   | Returns the number of development cards remaining in the deck                                                                                                                                                                                                          |
 
 **Robber logic (triggered internally when `rollDice()` returns 7):**
 1. No resources are produced.
@@ -211,7 +244,9 @@ src/main/java/domain/
 ├── DiceRoll.java              (NEW)
 ├── Bank.java                  (NEW)
 ├── TradeOffer.java            (NEW)
-└── Turn.java                  (NEW)
+├── Turn.java                  (NEW)
+├── DevelopmentCardType.java   (enum — NEW)
+└── DevelopmentCard.java       (NEW)
 
 src/test/java/domain/
 ├── HexTest.java               (existing)
@@ -222,7 +257,8 @@ src/test/java/domain/
 ├── DiceRollTest.java          (NEW)
 ├── BankTest.java              (NEW)
 ├── TradeOfferTest.java        (NEW)
-└── TurnTest.java              (NEW)
+├── TurnTest.java              (NEW)
+└── DevelopmentCardTest.java   (NEW)
 ```
 
 ---

--- a/src/main/java/domain/Bank.java
+++ b/src/main/java/domain/Bank.java
@@ -3,7 +3,7 @@ package domain;
 import java.util.EnumMap;
 import java.util.Map;
 
-public class Bank {
+public final class Bank {
 
     private static final int STANDARD_RESOURCE_COUNT = 19;
     private final Map<ResourceType, Integer> resources;

--- a/src/main/java/domain/DevelopmentCard.java
+++ b/src/main/java/domain/DevelopmentCard.java
@@ -20,4 +20,8 @@ public class DevelopmentCard {
     public DevelopmentCardType getType() {
         return type;
     }
+
+    public void markAsPlayed() {
+        this.played = true;
+    }
 }

--- a/src/main/java/domain/DevelopmentCard.java
+++ b/src/main/java/domain/DevelopmentCard.java
@@ -4,11 +4,16 @@ import java.util.Objects;
 
 public class DevelopmentCard {
     private final DevelopmentCardType type;
+    private boolean played = false;
 
     public DevelopmentCard(DevelopmentCardType type) {
         if (type == null) {
             throw new IllegalArgumentException("DevelopmentCard type cannot be null");
         }
         this.type = type;
+    }
+
+    public boolean isPlayed() {
+        return played;
     }
 }

--- a/src/main/java/domain/DevelopmentCard.java
+++ b/src/main/java/domain/DevelopmentCard.java
@@ -1,8 +1,6 @@
 package domain;
 
-import java.util.Objects;
-
-public class DevelopmentCard {
+public final class DevelopmentCard {
     private final DevelopmentCardType type;
     private boolean played = false;
 

--- a/src/main/java/domain/DevelopmentCard.java
+++ b/src/main/java/domain/DevelopmentCard.java
@@ -1,0 +1,14 @@
+package domain;
+
+import java.util.Objects;
+
+public class DevelopmentCard {
+    private final DevelopmentCardType type;
+
+    public DevelopmentCard(DevelopmentCardType type) {
+        if (type == null) {
+            throw new IllegalArgumentException("DevelopmentCard type cannot be null");
+        }
+        this.type = type;
+    }
+}

--- a/src/main/java/domain/DevelopmentCard.java
+++ b/src/main/java/domain/DevelopmentCard.java
@@ -22,6 +22,9 @@ public class DevelopmentCard {
     }
 
     public void markAsPlayed() {
+        if (played) {
+            throw new IllegalStateException("Card has already been played");
+        }
         this.played = true;
     }
 }

--- a/src/main/java/domain/DevelopmentCard.java
+++ b/src/main/java/domain/DevelopmentCard.java
@@ -16,4 +16,8 @@ public class DevelopmentCard {
     public boolean isPlayed() {
         return played;
     }
+
+    public DevelopmentCardType getType() {
+        return type;
+    }
 }

--- a/src/main/java/domain/DevelopmentCard.java
+++ b/src/main/java/domain/DevelopmentCard.java
@@ -20,6 +20,9 @@ public final class DevelopmentCard {
     }
 
     public void markAsPlayed() {
+        if (type == DevelopmentCardType.VICTORY_POINT) {
+            throw new IllegalStateException("Victory Point cards cannot be marked as played");
+        }
         if (played) {
             throw new IllegalStateException("Card has already been played");
         }

--- a/src/main/java/domain/DevelopmentCardType.java
+++ b/src/main/java/domain/DevelopmentCardType.java
@@ -1,0 +1,5 @@
+package domain;
+
+public enum DevelopmentCardType {
+    KNIGHT, ROAD_BUILDING, YEAR_OF_PLENTY, MONOPOLY, VICTORY_POINT
+}

--- a/src/main/java/domain/Game.java
+++ b/src/main/java/domain/Game.java
@@ -12,7 +12,7 @@ import java.util.Objects;
  *
  */
 
-public class Game {
+public final class Game {
 
     private static final int MIN_PLAYERS = 2;
     private static final int MAX_PLAYERS = 4;

--- a/src/test/java/domain/DevelopmentCardTest.java
+++ b/src/test/java/domain/DevelopmentCardTest.java
@@ -21,4 +21,10 @@ public class DevelopmentCardTest {
         DevelopmentCard card = new DevelopmentCard(DevelopmentCardType.KNIGHT);
         assertFalse(card.isPlayed());
     }
+
+    @Test
+    void GetType_ReturnsCorrectType() {
+        DevelopmentCard card = new DevelopmentCard(DevelopmentCardType.ROAD_BUILDING);
+        assertEquals(DevelopmentCardType.ROAD_BUILDING, card.getType());
+    }
 }

--- a/src/test/java/domain/DevelopmentCardTest.java
+++ b/src/test/java/domain/DevelopmentCardTest.java
@@ -47,4 +47,10 @@ public class DevelopmentCardTest {
         card.markAsPlayed();
         assertThrows(IllegalStateException.class, card::markAsPlayed);
     }
+
+    @Test
+    void MarkAsPlayed_OnVictoryPointCard_ThrowsIllegalStateException() {
+        DevelopmentCard card = new DevelopmentCard(DevelopmentCardType.VICTORY_POINT);
+        assertThrows(IllegalStateException.class, () -> card.markAsPlayed());
+    }
 }

--- a/src/test/java/domain/DevelopmentCardTest.java
+++ b/src/test/java/domain/DevelopmentCardTest.java
@@ -27,4 +27,11 @@ public class DevelopmentCardTest {
         DevelopmentCard card = new DevelopmentCard(DevelopmentCardType.YEAR_OF_PLENTY);
         assertFalse(card.isPlayed());
     }
+
+    @Test
+    void IsPlayed_AfterMarkAsPlayed_ReturnsTrue() {
+        DevelopmentCard card = new DevelopmentCard(DevelopmentCardType.YEAR_OF_PLENTY);
+        card.markAsPlayed();
+        assertTrue(card.isPlayed());
+    }
 }

--- a/src/test/java/domain/DevelopmentCardTest.java
+++ b/src/test/java/domain/DevelopmentCardTest.java
@@ -2,6 +2,7 @@ package domain;
 
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class DevelopmentCardTest {
@@ -9,5 +10,10 @@ public class DevelopmentCardTest {
     @Test
     void Constructor_WithNullType_ThrowsIllegalArgumentException() {
         assertThrows(IllegalArgumentException.class, () -> new DevelopmentCard(null));
+    }
+
+    @Test
+    void Constructor_WithValidType_NoExceptionThrown() {
+        assertDoesNotThrow(() -> new DevelopmentCard(DevelopmentCardType.KNIGHT));
     }
 }

--- a/src/test/java/domain/DevelopmentCardTest.java
+++ b/src/test/java/domain/DevelopmentCardTest.java
@@ -34,4 +34,10 @@ public class DevelopmentCardTest {
         card.markAsPlayed();
         assertTrue(card.isPlayed());
     }
+
+    @Test
+    void MarkAsPlayed_OnUnplayedCard_NoExceptionThrown() {
+        DevelopmentCard card = new DevelopmentCard(DevelopmentCardType.MONOPOLY);
+        assertDoesNotThrow(card::markAsPlayed);
+    }
 }

--- a/src/test/java/domain/DevelopmentCardTest.java
+++ b/src/test/java/domain/DevelopmentCardTest.java
@@ -17,14 +17,14 @@ public class DevelopmentCardTest {
     }
 
     @Test
-    void Constructor_NewCard_IsNotPlayed() {
-        DevelopmentCard card = new DevelopmentCard(DevelopmentCardType.KNIGHT);
-        assertFalse(card.isPlayed());
-    }
-
-    @Test
     void GetType_ReturnsCorrectType() {
         DevelopmentCard card = new DevelopmentCard(DevelopmentCardType.ROAD_BUILDING);
         assertEquals(DevelopmentCardType.ROAD_BUILDING, card.getType());
+    }
+
+    @Test
+    void IsPlayed_WhenNewCard_ReturnsFalse() {
+        DevelopmentCard card = new DevelopmentCard(DevelopmentCardType.YEAR_OF_PLENTY);
+        assertFalse(card.isPlayed());
     }
 }

--- a/src/test/java/domain/DevelopmentCardTest.java
+++ b/src/test/java/domain/DevelopmentCardTest.java
@@ -8,7 +8,9 @@ public class DevelopmentCardTest {
 
     @Test
     void Constructor_WithNullType_ThrowsIllegalArgumentException() {
-        assertThrows(IllegalArgumentException.class, () -> new DevelopmentCard(null));
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+                () -> new DevelopmentCard(null));
+        assertEquals("DevelopmentCard type cannot be null", exception.getMessage());
     }
 
     @Test
@@ -45,12 +47,16 @@ public class DevelopmentCardTest {
     void MarkAsPlayed_OnAlreadyPlayedCard_ThrowsIllegalStateException() {
         DevelopmentCard card = new DevelopmentCard(DevelopmentCardType.MONOPOLY);
         card.markAsPlayed();
-        assertThrows(IllegalStateException.class, card::markAsPlayed);
+        IllegalStateException exception = assertThrows(IllegalStateException.class,
+                card::markAsPlayed);
+        assertEquals("Card has already been played", exception.getMessage());
     }
 
     @Test
     void MarkAsPlayed_OnVictoryPointCard_ThrowsIllegalStateException() {
         DevelopmentCard card = new DevelopmentCard(DevelopmentCardType.VICTORY_POINT);
-        assertThrows(IllegalStateException.class, () -> card.markAsPlayed());
+        IllegalStateException exception = assertThrows(IllegalStateException.class,
+                card::markAsPlayed);
+        assertEquals("Victory Point cards cannot be marked as played", exception.getMessage());
     }
 }

--- a/src/test/java/domain/DevelopmentCardTest.java
+++ b/src/test/java/domain/DevelopmentCardTest.java
@@ -1,0 +1,13 @@
+package domain;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class DevelopmentCardTest {
+
+    @Test
+    void Constructor_WithNullType_ThrowsIllegalArgumentException() {
+        assertThrows(IllegalArgumentException.class, () -> new DevelopmentCard(null));
+    }
+}

--- a/src/test/java/domain/DevelopmentCardTest.java
+++ b/src/test/java/domain/DevelopmentCardTest.java
@@ -40,4 +40,11 @@ public class DevelopmentCardTest {
         DevelopmentCard card = new DevelopmentCard(DevelopmentCardType.MONOPOLY);
         assertDoesNotThrow(card::markAsPlayed);
     }
+
+    @Test
+    void MarkAsPlayed_OnAlreadyPlayedCard_ThrowsIllegalStateException() {
+        DevelopmentCard card = new DevelopmentCard(DevelopmentCardType.MONOPOLY);
+        card.markAsPlayed();
+        assertThrows(IllegalStateException.class, card::markAsPlayed);
+    }
 }

--- a/src/test/java/domain/DevelopmentCardTest.java
+++ b/src/test/java/domain/DevelopmentCardTest.java
@@ -2,8 +2,7 @@ package domain;
 
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class DevelopmentCardTest {
 
@@ -15,5 +14,11 @@ public class DevelopmentCardTest {
     @Test
     void Constructor_WithValidType_NoExceptionThrown() {
         assertDoesNotThrow(() -> new DevelopmentCard(DevelopmentCardType.KNIGHT));
+    }
+
+    @Test
+    void Constructor_NewCard_IsNotPlayed() {
+        DevelopmentCard card = new DevelopmentCard(DevelopmentCardType.KNIGHT);
+        assertFalse(card.isPlayed());
     }
 }


### PR DESCRIPTION
Implements the DevelopmentCard class and DevelopmentCardType enum as part of the first turn phase. Includes BVA analysis and TDD tests. Part of the first turn implementation. Closes #52.