### PR TITLE
Implement logic for one turn

### DIFF
--- a/docs/bva/Board.md
+++ b/docs/bva/Board.md
@@ -226,6 +226,25 @@
   - **State of the system**: Valid board constructed, vertex 11 requested
   - **Expected output**: `Optional` containing `HarborType.LUMBER`
 
+## Method under test: `getRobberHex()`
+
+- **TC49: getRobberHex_NewBoard_StartsOnDesertHex** ( :white_check_mark: )
+  - **State of the system**: newly constructed board (robber not yet moved)
+  - **Expected output**: `getRobberHex().getTerrainType()` returns `TerrainType.DESERT`
+
+## Method under test: `setRobberHex(Hex)`
+
+- **TC50: setRobberHex_WithNull_ThrowsIllegalArgumentException** ( :white_check_mark: )
+  - **State of the system**: valid board, `null` passed as hex
+  - **Expected output**: `IllegalArgumentException`
+
+- **TC51: setRobberHex_WithHexNotOnBoard_ThrowsIllegalArgumentException** ( :white_check_mark: )
+  - **State of the system**: valid board, hex constructed independently of the board's hex list
+  - **Expected output**: `IllegalArgumentException`
+
+- **TC52: setRobberHex_WithHexOnBoard_UpdatesRobberHex** ( :white_check_mark: )
+  - **State of the system**: valid board, hex taken from `getHexes()`
+  - **Expected output**: `getRobberHex()` returns the given hex
 
 
 

--- a/docs/bva/Turn.md
+++ b/docs/bva/Turn.md
@@ -278,6 +278,53 @@
   - State of the system: `target` is a valid robbing candidate holding exactly 1 resource card (boundary)
   - Expected output: `target`'s count for that resource becomes `0`; `activePlayer`'s count for that resource becomes `1`
 
+## Method under test: `advanceToBuild()`
+
+- **TC64: AdvanceToBuild_FromTradePhase_SetsPhaseToBuild** ( :white_check_mark: )
+  - State of the system: dice rolled (non-7), turn is in TRADE phase, no robber resolution pending
+  - Expected output: `getPhase()` returns `TurnPhase.BUILD`
+
+- **TC65: AdvanceToBuild_FromProductionPhase_ThrowsIllegalStateException** ( :white_check_mark: )
+  - State of the system: `rollDice()` not yet called, turn is still in PRODUCTION phase
+  - Expected output: `IllegalStateException`
+
+- **TC66: AdvanceToBuild_FromBuildPhase_ThrowsIllegalStateException** ( :white_check_mark: )
+  - State of the system: `advanceToBuild()` already called once this turn (boundary: calling it again)
+  - Expected output: `IllegalStateException`
+
+- **TC67: AdvanceToBuild_WithRobberMovePending_ThrowsIllegalStateException** ( :white_check_mark: )
+  - State of the system: a 7 was just rolled and `moveRobber()` has not yet been called
+  - Expected output: `IllegalStateException`
+
+- **TC68: AdvanceToBuild_WithStealPending_ThrowsIllegalStateException** ( :white_check_mark: )
+  - State of the system: a 7 was rolled, robber moved onto a hex with an eligible candidate, `steal()` not yet called
+  - Expected output: `IllegalStateException`
+
+- **TC69: AdvanceToBuild_AfterRobberFullyResolved_SetsPhaseToBuild** ( :white_check_mark: )
+  - State of the system: a 7 was rolled, robber moved and `steal()` completed (boundary: last required robber step just finished)
+  - Expected output: `getPhase()` returns `TurnPhase.BUILD`
+
+- **TC70: AdvanceToBuild_AfterRobberMovedWithNoCandidates_SetsPhaseToBuild** ( :white_check_mark: )
+  - State of the system: a 7 was rolled, robber moved onto a hex with no adjacent settlements (no steal required)
+  - Expected output: `getPhase()` returns `TurnPhase.BUILD`
+
+## Method under test: `endTurn()`
+
+- **TC71: EndTurn_FromBuildPhase_SetsPhaseToDone** ( :white_check_mark: )
+  - State of the system: turn has advanced to BUILD phase
+  - Expected output: `getPhase()` returns `TurnPhase.DONE`
+
+- **TC72: EndTurn_FromTradePhase_ThrowsIllegalStateException** ( :white_check_mark: )
+  - State of the system: dice rolled, turn is in TRADE phase (boundary: one phase before BUILD)
+  - Expected output: `IllegalStateException`
+
+- **TC73: EndTurn_FromProductionPhase_ThrowsIllegalStateException** ( :white_check_mark: )
+  - State of the system: `rollDice()` not yet called, turn is still in PRODUCTION phase
+  - Expected output: `IllegalStateException`
+
+- **TC74: EndTurn_CalledTwice_ThrowsIllegalStateException** ( :white_check_mark: )
+  - State of the system: `endTurn()` already called once this turn, phase is DONE (boundary: calling it again)
+  - Expected output: `IllegalStateException`
 
 
 

--- a/docs/bva/Turn.md
+++ b/docs/bva/Turn.md
@@ -168,7 +168,115 @@
   - State of the system: valid `vertexId`, vertex is occupied by player's own settlement
   - Expected output: `getOwner` called on `vertexId` returns `activePlayer`, `isCity` called on `vertexId` returns True
 
-  
+## Method under test: `rollDice()`
+
+- **TC40: RollDice_ValidCall_ReturnsRollValue** ( :white_check_mark: )
+  - State of the system: `phase = PRODUCTION`, dice mocked to return 8
+  - Expected output: `rollDice()` returns `8`
+
+- **TC41: RollDice_ValidCall_AdvancesPhaseToTrade** ( :white_check_mark: )
+  - State of the system: `phase = PRODUCTION`, valid roll
+  - Expected output: `getPhase()` returns `TRADE`
+
+- **TC42: RollDice_CalledOutsideProductionPhase_ThrowsIllegalStateException** ( :white_check_mark: )
+  - State of the system: `rollDice()` already called once this turn (phase advanced to `TRADE`)
+  - Expected output: `IllegalStateException`
+
+- **TC43: RollDice_NonSevenRoll_DistributesResourcesToSettlementOwner** ( :white_check_mark: )
+  - State of the system: roll = 8 (non-7, boundary above robber trigger), `activePlayer` owns a settlement adjacent to a producing hex with number token 8
+  - Expected output: `getResourceCount` for the produced resource is greater than 0
+
+- **TC44: RollDice_RollOfSeven_NoResourcesDistributed** ( :white_check_mark: )
+  - State of the system: roll = 7 (boundary), `activePlayer` owns a settlement adjacent to a producing hex
+  - Expected output: `getTotalResourceCount()` returns `0`
+
+## Method under test: `isSevenRolled()`
+
+- **TC45: IsSevenRolled_BeforeRollingDice_ReturnsFalse** ( :white_check_mark: )
+  - State of the system: `rollDice()` not yet called this turn
+  - Expected output: `false`
+
+- **TC46: IsSevenRolled_AfterRollingSeven_ReturnsTrue** ( :white_check_mark: )
+  - State of the system: `rollDice()` called, dice mocked to return 7 (boundary)
+  - Expected output: `true`
+
+- **TC47: IsSevenRolled_AfterRollingNonSeven_ReturnsFalse** ( :white_check_mark: )
+  - State of the system: `rollDice()` called, dice mocked to return 8 (one above the boundary)
+  - Expected output: `false`
+
+## Robber logic — triggered internally by `rollDice()` on a roll of 7
+
+### `enforceDiscard()` (private; exercised through `rollDice()`)
+
+- **TC48: RollDice_RollOfSeven_PlayerWithSevenCards_NoDiscard** ( :white_check_mark: )
+  - State of the system: roll = 7, an opponent holds exactly 7 resource cards (boundary — at the discard threshold but not over)
+  - Expected output: opponent's `getTotalResourceCount()` remains `7`
+
+- **TC49: RollDice_RollOfSeven_PlayerWithEightCards_DiscardsFour** ( :white_check_mark: )
+  - State of the system: roll = 7, an opponent holds exactly 8 resource cards (one above the boundary; `floor(8/2) = 4`)
+  - Expected output: opponent's `getTotalResourceCount()` becomes `4`
+
+- **TC50: RollDice_RollOfSeven_PlayerWithNineCards_DiscardsFour** ( :white_check_mark: )
+  - State of the system: roll = 7, an opponent holds 9 resource cards across two types (`floor(9/2) = 4`)
+  - Expected output: opponent's `getTotalResourceCount()` becomes `5`
+
+### `getRobbingCandidates()`
+
+- **TC51: GetRobbingCandidates_OpponentSettlementAdjacentToRobberHex_IncludesOpponent** ( :white_check_mark: )
+  - State of the system: an opponent owns a settlement on a vertex adjacent to the robber's hex
+  - Expected output: returned list contains the opponent
+
+- **TC52: GetRobbingCandidates_ActivePlayerSettlementAdjacentToRobberHex_ExcludesActivePlayer** ( :white_check_mark: )
+  - State of the system: `activePlayer` owns a settlement on a vertex adjacent to the robber's hex
+  - Expected output: returned list does not contain `activePlayer`
+
+- **TC53: GetRobbingCandidates_NoSettlementsAdjacentToRobberHex_ReturnsEmptyList** ( :white_check_mark: )
+  - State of the system: no vertex adjacent to the robber's hex is occupied
+  - Expected output: returned list is empty
+
+### `moveRobber(int hexId)`
+
+- **TC54: MoveRobber_BeforeSevenRolled_ThrowsIllegalStateException** ( :white_check_mark: )
+  - State of the system: `rollDice()` not yet called (or last roll was not a 7)
+  - Expected output: `IllegalStateException`
+
+- **TC55: MoveRobber_ToCurrentRobberHex_ThrowsIllegalArgumentException** ( :white_check_mark: )
+  - State of the system: 7 just rolled, `hexId` identifies the hex the robber is already on
+  - Expected output: `IllegalArgumentException`
+
+- **TC56: MoveRobber_WithInvalidHexId_ThrowsIllegalArgumentException** ( :white_check_mark: )
+  - State of the system: 7 just rolled, `hexId = 99` (out of the board's [0, 18] range)
+  - Expected output: `IllegalArgumentException`
+
+- **TC57: MoveRobber_ToValidHex_UpdatesBoardRobberHex** ( :white_check_mark: )
+  - State of the system: 7 just rolled, `hexId` identifies a different, valid hex
+  - Expected output: `board.getRobberHex()` returns the targeted hex
+
+- **TC58: MoveRobber_CalledTwice_ThrowsIllegalStateException** ( :white_check_mark: )
+  - State of the system: robber already moved once this turn
+  - Expected output: `IllegalStateException`
+
+### `steal(Player target)`
+
+- **TC59: Steal_BeforeMovingRobber_ThrowsIllegalStateException** ( :white_check_mark: )
+  - State of the system: 7 just rolled, robber not yet moved this turn
+  - Expected output: `IllegalStateException`
+
+- **TC60: Steal_WhenNoRobbingCandidates_ThrowsIllegalStateException** ( :white_check_mark: )
+  - State of the system: robber moved to a hex with no adjacent settlements
+  - Expected output: `IllegalStateException`
+
+- **TC61: Steal_FromPlayerNotAdjacentToRobberHex_ThrowsIllegalArgumentException** ( :white_check_mark: )
+  - State of the system: robber moved to a hex; `target` does not own a settlement adjacent to it (a different player does)
+  - Expected output: `IllegalArgumentException`
+
+- **TC62: Steal_TargetHasNoResourceCards_ThrowsIllegalStateException** ( :white_check_mark: )
+  - State of the system: `target` is a valid robbing candidate but holds 0 resource cards (boundary)
+  - Expected output: `IllegalStateException`
+
+- **TC63: Steal_FromValidCandidate_TransfersOneResourceCardToActivePlayer** ( :white_check_mark: )
+  - State of the system: `target` is a valid robbing candidate holding exactly 1 resource card (boundary)
+  - Expected output: `target`'s count for that resource becomes `0`; `activePlayer`'s count for that resource becomes `1`
 
 
 

--- a/docs/bva/Turn.md
+++ b/docs/bva/Turn.md
@@ -340,5 +340,65 @@
   - State of the system: turn still in PRODUCTION phase (`rollDice()` not yet called)
   - Expected output: `IllegalStateException`
 
+## Method under test: `proposeTrade(Player recipient, Map<ResourceType, Integer> offering, Map<ResourceType, Integer> requesting)`
+
+- **TC78: ProposeTrade_OutsideTradePhase_ThrowsIllegalStateException** ( :white_check_mark: )
+  - State of the system: turn still in PRODUCTION phase (`rollDice()` not yet called)
+  - Expected output: `IllegalStateException`
+
+- **TC79: ProposeTrade_WhenTradeAlreadyPending_ThrowsIllegalStateException** ( :white_check_mark: )
+  - State of the system: a prior `proposeTrade()` call already created a `PENDING` offer this turn
+  - Expected output: `IllegalStateException`
+
+- **TC80: ProposeTrade_OffererCannotAffordOffering_ThrowsIllegalArgumentException** ( :white_check_mark: )
+  - State of the system: active player has 0 of a resource type included in `offering` (boundary)
+  - Expected output: `IllegalArgumentException`
+
+- **TC81: ProposeTrade_OffererHasExactlyOfferedAmount_CreatesAndStoresPendingTrade** ( :white_check_mark: )
+  - State of the system: active player has exactly the amount of each resource included in `offering` (boundary)
+  - Expected output: a `PENDING` `TradeOffer` is returned and `getPendingTrade()` returns it
+
+- **TC82: ProposeTrade_AfterPriorOfferResolved_CreatesNewPendingTrade** ( :white_check_mark: )
+  - State of the system: a prior offer was accepted/rejected and `pendingTrade` was cleared
+  - Expected output: a new `PENDING` `TradeOffer` is created and stored as the pending trade
+
+## Method under test: `acceptTrade(TradeOffer offer)`
+
+- **TC83: AcceptTrade_NoMatchingPendingTrade_ThrowsIllegalStateException** ( :white_check_mark: )
+  - State of the system: no trade is pending, or the supplied `offer` is not the stored `pendingTrade`
+  - Expected output: `IllegalStateException`
+
+- **TC84: AcceptTrade_OffererCannotAffordOffering_ThrowsIllegalStateException** ( :white_check_mark: )
+  - State of the system: offer is pending, but the offerer no longer holds enough of a resource in `offering` (boundary: 0 of a required resource)
+  - Expected output: `IllegalStateException`
+
+- **TC85: AcceptTrade_RecipientCannotAffordRequesting_ThrowsIllegalStateException** ( :white_check_mark: )
+  - State of the system: offer is pending, offerer can afford `offering`, but the recipient has 0 of a resource in `requesting` (boundary)
+  - Expected output: `IllegalStateException`
+
+- **TC86: AcceptTrade_BothPlayersCanAfford_ExchangesResourcesAndClearsPendingTrade** ( :white_check_mark: )
+  - State of the system: offerer holds exactly the offered amounts, recipient holds exactly the requested amounts (boundary)
+  - Expected output: offerer's and recipient's resource counts reflect the exchange, offer status becomes `ACCEPTED`, and `getPendingTrade()` returns empty
+
+## Method under test: `rejectTrade(TradeOffer offer)`
+
+- **TC87: RejectTrade_NoMatchingPendingTrade_ThrowsIllegalStateException** ( :white_check_mark: )
+  - State of the system: no trade is pending, or the supplied `offer` is not the stored `pendingTrade`
+  - Expected output: `IllegalStateException`
+
+- **TC88: RejectTrade_PendingOffer_MarksRejectedAndClearsPendingTrade** ( :white_check_mark: )
+  - State of the system: a `PENDING` offer is the stored `pendingTrade`
+  - Expected output: `offer.getStatus()` becomes `REJECTED` and `getPendingTrade()` returns empty
+
+## Method under test: `getPendingTrade()`
+
+- **TC89: GetPendingTrade_NoOfferProposed_ReturnsEmpty** ( :white_check_mark: )
+  - State of the system: `proposeTrade()` has not been called this turn
+  - Expected output: `Optional.empty()`
+
+- **TC90: GetPendingTrade_AfterProposeTrade_ReturnsTheOffer** ( :white_check_mark: )
+  - State of the system: `proposeTrade()` was just called and returned a `PENDING` offer
+  - Expected output: `Optional` containing that exact `TradeOffer`
+
 
 

--- a/docs/bva/Turn.md
+++ b/docs/bva/Turn.md
@@ -190,6 +190,10 @@
   - State of the system: roll = 7 (boundary), `activePlayer` owns a settlement adjacent to a producing hex
   - Expected output: `getTotalResourceCount()` returns `0`
 
+- **TC109: RollDice_NumberMatchesRobberHex_DoesNotProduceFromThatHex** ( :white_check_mark: )
+  - State of the system: roll matches the number token of the hex the robber currently occupies, `activePlayer` owns a settlement adjacent only to that hex for the rolled number
+  - Expected output: `getTotalResourceCount()` returns `0` (the robbed hex produces nothing even on a matching roll)
+
 ## Method under test: `isSevenRolled()`
 
 - **TC45: IsSevenRolled_BeforeRollingDice_ReturnsFalse** ( :white_check_mark: )
@@ -270,9 +274,9 @@
   - State of the system: robber moved to a hex; `target` does not own a settlement adjacent to it (a different player does)
   - Expected output: `IllegalArgumentException`
 
-- **TC62: Steal_TargetHasNoResourceCards_ThrowsIllegalStateException** ( :white_check_mark: )
+- **TC62: Steal_TargetHasNoResourceCards_CompletesWithNoTransferAndResolvesRobber** ( :white_check_mark: )
   - State of the system: `target` is a valid robbing candidate but holds 0 resource cards (boundary)
-  - Expected output: `IllegalStateException`
+  - Expected output: no resource cards change hands, and the robber is fully resolved (`advanceToBuild()` no longer throws — a target with no cards cannot leave the turn permanently stuck)
 
 - **TC63: Steal_FromValidCandidate_TransfersOneResourceCardToActivePlayer** ( :white_check_mark: )
   - State of the system: `target` is a valid robbing candidate holding exactly 1 resource card (boundary)
@@ -307,6 +311,10 @@
 - **TC70: AdvanceToBuild_AfterRobberMovedWithNoCandidates_SetsPhaseToBuild** ( :white_check_mark: )
   - State of the system: a 7 was rolled, robber moved onto a hex with no adjacent settlements (no steal required)
   - Expected output: `getPhase()` returns `TurnPhase.BUILD`
+
+- **TC108: AdvanceToBuild_WithPendingTrade_RejectsAndClearsTheOffer** ( :white_check_mark: )
+  - State of the system: turn is in TRADE phase with a pending trade offer that has not yet been accepted or rejected
+  - Expected output: the offer's status becomes `REJECTED` and `getPendingTrade()` returns empty (a pending offer expires when the active player moves on to the build phase)
 
 ## Method under test: `endTurn()`
 
@@ -448,6 +456,10 @@
 
 - **TC101: PlayDevelopmentCard_CardAlreadyPlayed_ThrowsIllegalStateException** ( :white_check_mark: )
   - State of the system: `card.isPlayed()` is already `true` (acquired and played in a previous turn)
+  - Expected output: `IllegalStateException`
+
+- **TC110: PlayDevelopmentCard_VictoryPointCard_ThrowsIllegalStateException** ( :white_check_mark: )
+  - State of the system: `card` is a `VICTORY_POINT` card in the active player's hand (boundary: the one card type that can never be played through this method — per the rules it is instead privately revealed to declare victory, which requires whole-game VP tracking that is out of scope for a single turn)
   - Expected output: `IllegalStateException`
 
 - **TC102: PlayDevelopmentCard_UnplayedCardFromPriorTurn_MarksCardAsPlayed** ( :white_check_mark: )

--- a/docs/bva/Turn.md
+++ b/docs/bva/Turn.md
@@ -326,6 +326,19 @@
   - State of the system: `endTurn()` already called once this turn, phase is DONE (boundary: calling it again)
   - Expected output: `IllegalStateException`
 
+## Build-phase enforcement: `buildRoad(int)`, `buildSettlement(int)`, `buildCity(int)`
+
+- **TC75: BuildRoad_OutsideBuildPhase_ThrowsIllegalStateException** ( :white_check_mark: )
+  - State of the system: turn still in PRODUCTION phase (`rollDice()` not yet called, boundary: one phase before BUILD is reachable)
+  - Expected output: `IllegalStateException`
+
+- **TC76: BuildSettlement_OutsideBuildPhase_ThrowsIllegalStateException** ( :white_check_mark: )
+  - State of the system: turn still in PRODUCTION phase (`rollDice()` not yet called)
+  - Expected output: `IllegalStateException`
+
+- **TC77: BuildCity_OutsideBuildPhase_ThrowsIllegalStateException** ( :white_check_mark: )
+  - State of the system: turn still in PRODUCTION phase (`rollDice()` not yet called)
+  - Expected output: `IllegalStateException`
 
 
 

--- a/docs/bva/Turn.md
+++ b/docs/bva/Turn.md
@@ -402,79 +402,79 @@
 
 ## Method under test: `submitMaritimeTrade(MaritimeTrade trade)`
 
-- **TC91: SubmitMaritimeTrade_OutsideTradePhase_ThrowsIllegalStateException**
+- **TC91: SubmitMaritimeTrade_OutsideTradePhase_ThrowsIllegalStateException** ( :white_check_mark: )
   - State of the system: turn has advanced to the BUILD phase
   - Expected output: `IllegalStateException`
 
-- **TC92: SubmitMaritimeTrade_BankHasNoneOfReceivingResource_ThrowsIllegalStateException**
+- **TC92: SubmitMaritimeTrade_BankHasNoneOfReceivingResource_ThrowsIllegalStateException** ( :white_check_mark: )
   - State of the system: turn is in TRADE phase, bank holds 0 of the trade's `receiving` resource (boundary)
   - Expected output: `IllegalStateException`
 
-- **TC93: SubmitMaritimeTrade_BankHasExactlyOneOfReceivingResource_ExecutesTrade**
+- **TC93: SubmitMaritimeTrade_BankHasExactlyOneOfReceivingResource_ExecutesTrade** ( :white_check_mark: )
   - State of the system: turn is in TRADE phase, bank holds exactly 1 of the `receiving` resource (boundary), player holds at least `amount` of `giving`
   - Expected output: player's `giving` count decreases by `amount` and `receiving` count increases by 1; bank's `giving` count increases by `amount` and `receiving` count decreases by 1
 
 ## Method under test: `buyDevelopmentCard()`
 
-- **TC94: BuyDevelopmentCard_OutsideBuildPhase_ThrowsIllegalStateException**
+- **TC94: BuyDevelopmentCard_OutsideBuildPhase_ThrowsIllegalStateException** ( :white_check_mark: )
   - State of the system: turn still in TRADE phase (not yet advanced to BUILD)
   - Expected output: `IllegalStateException`
 
-- **TC95: BuyDevelopmentCard_PlayerCannotAffordCost_ThrowsIllegalStateException**
+- **TC95: BuyDevelopmentCard_PlayerCannotAffordCost_ThrowsIllegalStateException** ( :white_check_mark: )
   - State of the system: turn is in BUILD phase, active player has 0 of one required resource (Ore, Wool, or Grain) (boundary)
   - Expected output: `IllegalStateException`
 
-- **TC96: BuyDevelopmentCard_NoCardsRemainInDeck_ThrowsIllegalStateException**
+- **TC96: BuyDevelopmentCard_NoCardsRemainInDeck_ThrowsIllegalStateException** ( :white_check_mark: )
   - State of the system: turn is in BUILD phase, active player can afford the cost, `getRemainingDeckSize()` is 0 (boundary)
   - Expected output: `IllegalStateException`
 
-- **TC97: BuyDevelopmentCard_PlayerHasExactCostAndOneCardRemains_DeductsCostAndAddsCardToHand**
+- **TC97: BuyDevelopmentCard_PlayerHasExactCostAndOneCardRemains_DeductsCostAndAddsCardToHand** ( :white_check_mark: )
   - State of the system: turn is in BUILD phase, active player has exactly 1 Ore + 1 Wool + 1 Grain, exactly 1 card remains in the deck (boundary)
   - Expected output: player's Ore/Wool/Grain counts become `0`, `getRemainingDeckSize()` becomes `0`, and `getPlayerHand(activePlayer)` grows by one card
 
 ## Method under test: `playDevelopmentCard(Player player, DevelopmentCard card)`
 
-- **TC98: PlayDevelopmentCard_OutsideTradeOrBuildPhase_ThrowsIllegalStateException**
+- **TC98: PlayDevelopmentCard_OutsideTradeOrBuildPhase_ThrowsIllegalStateException** ( :white_check_mark: )
   - State of the system: turn still in PRODUCTION phase (`rollDice()` not yet called, boundary: one phase before TRADE)
   - Expected output: `IllegalStateException`
 
-- **TC99: PlayDevelopmentCard_DevCardAlreadyPlayedThisTurn_ThrowsIllegalStateException**
+- **TC99: PlayDevelopmentCard_DevCardAlreadyPlayedThisTurn_ThrowsIllegalStateException** ( :white_check_mark: )
   - State of the system: a (different) development card was already played earlier this turn
   - Expected output: `IllegalStateException`
 
-- **TC100: PlayDevelopmentCard_NonVictoryPointCardPurchasedThisTurn_ThrowsIllegalStateException**
+- **TC100: PlayDevelopmentCard_NonVictoryPointCardPurchasedThisTurn_ThrowsIllegalStateException** ( :white_check_mark: )
   - State of the system: card is a non-`VICTORY_POINT` card bought via `buyDevelopmentCard()` earlier in this same turn (boundary)
   - Expected output: `IllegalStateException`
 
-- **TC101: PlayDevelopmentCard_CardAlreadyPlayed_ThrowsIllegalStateException**
+- **TC101: PlayDevelopmentCard_CardAlreadyPlayed_ThrowsIllegalStateException** ( :white_check_mark: )
   - State of the system: `card.isPlayed()` is already `true` (acquired and played in a previous turn)
   - Expected output: `IllegalStateException`
 
-- **TC102: PlayDevelopmentCard_UnplayedCardFromPriorTurn_MarksCardAsPlayed**
+- **TC102: PlayDevelopmentCard_UnplayedCardFromPriorTurn_MarksCardAsPlayed** ( :white_check_mark: )
   - State of the system: turn is in TRADE or BUILD phase, `card` is an unplayed non-`VICTORY_POINT` card the player acquired in a previous turn (boundary: minimal valid preconditions)
   - Expected output: `card.isPlayed()` becomes `true`
 
 ## Method under test: `getPlayerHand(Player player)`
 
-- **TC103: GetPlayerHand_PlayerWithNoCards_ReturnsEmptyList**
+- **TC103: GetPlayerHand_PlayerWithNoCards_ReturnsEmptyList** ( :white_check_mark: )
   - State of the system: `player` has not purchased any development cards (boundary)
   - Expected output: empty list
 
-- **TC104: GetPlayerHand_AfterBuyingOneCard_ReturnsListContainingPurchasedCard**
+- **TC104: GetPlayerHand_AfterBuyingOneCard_ReturnsListContainingPurchasedCard** ( :white_check_mark: )
   - State of the system: `player` purchased exactly one development card via `buyDevelopmentCard()` (boundary)
   - Expected output: list of size `1` containing that card
 
-- **TC105: GetPlayerHand_ReturnedList_IsUnmodifiable**
+- **TC105: GetPlayerHand_ReturnedList_IsUnmodifiable** ( :white_check_mark: )
   - State of the system: a hand list obtained via `getPlayerHand()`
   - Expected output: `UnsupportedOperationException` on attempted mutation
 
 ## Method under test: `getRemainingDeckSize()`
 
-- **TC106: GetRemainingDeckSize_NewTurn_Returns25**
+- **TC106: GetRemainingDeckSize_NewTurn_Returns25** ( :white_check_mark: )
   - State of the system: no cards have been purchased yet this game (boundary: full 14 KNIGHT + 6 Progress + 5 VICTORY_POINT deck)
   - Expected output: `25`
 
-- **TC107: GetRemainingDeckSize_AfterBuyingOneCard_DecreasesByOne**
+- **TC107: GetRemainingDeckSize_AfterBuyingOneCard_DecreasesByOne** ( :white_check_mark: )
   - State of the system: exactly one card has been purchased via `buyDevelopmentCard()` (boundary)
   - Expected output: `24`
 

--- a/docs/bva/Turn.md
+++ b/docs/bva/Turn.md
@@ -400,5 +400,83 @@
   - State of the system: `proposeTrade()` was just called and returned a `PENDING` offer
   - Expected output: `Optional` containing that exact `TradeOffer`
 
+## Method under test: `submitMaritimeTrade(MaritimeTrade trade)`
+
+- **TC91: SubmitMaritimeTrade_OutsideTradePhase_ThrowsIllegalStateException**
+  - State of the system: turn has advanced to the BUILD phase
+  - Expected output: `IllegalStateException`
+
+- **TC92: SubmitMaritimeTrade_BankHasNoneOfReceivingResource_ThrowsIllegalStateException**
+  - State of the system: turn is in TRADE phase, bank holds 0 of the trade's `receiving` resource (boundary)
+  - Expected output: `IllegalStateException`
+
+- **TC93: SubmitMaritimeTrade_BankHasExactlyOneOfReceivingResource_ExecutesTrade**
+  - State of the system: turn is in TRADE phase, bank holds exactly 1 of the `receiving` resource (boundary), player holds at least `amount` of `giving`
+  - Expected output: player's `giving` count decreases by `amount` and `receiving` count increases by 1; bank's `giving` count increases by `amount` and `receiving` count decreases by 1
+
+## Method under test: `buyDevelopmentCard()`
+
+- **TC94: BuyDevelopmentCard_OutsideBuildPhase_ThrowsIllegalStateException**
+  - State of the system: turn still in TRADE phase (not yet advanced to BUILD)
+  - Expected output: `IllegalStateException`
+
+- **TC95: BuyDevelopmentCard_PlayerCannotAffordCost_ThrowsIllegalStateException**
+  - State of the system: turn is in BUILD phase, active player has 0 of one required resource (Ore, Wool, or Grain) (boundary)
+  - Expected output: `IllegalStateException`
+
+- **TC96: BuyDevelopmentCard_NoCardsRemainInDeck_ThrowsIllegalStateException**
+  - State of the system: turn is in BUILD phase, active player can afford the cost, `getRemainingDeckSize()` is 0 (boundary)
+  - Expected output: `IllegalStateException`
+
+- **TC97: BuyDevelopmentCard_PlayerHasExactCostAndOneCardRemains_DeductsCostAndAddsCardToHand**
+  - State of the system: turn is in BUILD phase, active player has exactly 1 Ore + 1 Wool + 1 Grain, exactly 1 card remains in the deck (boundary)
+  - Expected output: player's Ore/Wool/Grain counts become `0`, `getRemainingDeckSize()` becomes `0`, and `getPlayerHand(activePlayer)` grows by one card
+
+## Method under test: `playDevelopmentCard(Player player, DevelopmentCard card)`
+
+- **TC98: PlayDevelopmentCard_OutsideTradeOrBuildPhase_ThrowsIllegalStateException**
+  - State of the system: turn still in PRODUCTION phase (`rollDice()` not yet called, boundary: one phase before TRADE)
+  - Expected output: `IllegalStateException`
+
+- **TC99: PlayDevelopmentCard_DevCardAlreadyPlayedThisTurn_ThrowsIllegalStateException**
+  - State of the system: a (different) development card was already played earlier this turn
+  - Expected output: `IllegalStateException`
+
+- **TC100: PlayDevelopmentCard_NonVictoryPointCardPurchasedThisTurn_ThrowsIllegalStateException**
+  - State of the system: card is a non-`VICTORY_POINT` card bought via `buyDevelopmentCard()` earlier in this same turn (boundary)
+  - Expected output: `IllegalStateException`
+
+- **TC101: PlayDevelopmentCard_CardAlreadyPlayed_ThrowsIllegalStateException**
+  - State of the system: `card.isPlayed()` is already `true` (acquired and played in a previous turn)
+  - Expected output: `IllegalStateException`
+
+- **TC102: PlayDevelopmentCard_UnplayedCardFromPriorTurn_MarksCardAsPlayed**
+  - State of the system: turn is in TRADE or BUILD phase, `card` is an unplayed non-`VICTORY_POINT` card the player acquired in a previous turn (boundary: minimal valid preconditions)
+  - Expected output: `card.isPlayed()` becomes `true`
+
+## Method under test: `getPlayerHand(Player player)`
+
+- **TC103: GetPlayerHand_PlayerWithNoCards_ReturnsEmptyList**
+  - State of the system: `player` has not purchased any development cards (boundary)
+  - Expected output: empty list
+
+- **TC104: GetPlayerHand_AfterBuyingOneCard_ReturnsListContainingPurchasedCard**
+  - State of the system: `player` purchased exactly one development card via `buyDevelopmentCard()` (boundary)
+  - Expected output: list of size `1` containing that card
+
+- **TC105: GetPlayerHand_ReturnedList_IsUnmodifiable**
+  - State of the system: a hand list obtained via `getPlayerHand()`
+  - Expected output: `UnsupportedOperationException` on attempted mutation
+
+## Method under test: `getRemainingDeckSize()`
+
+- **TC106: GetRemainingDeckSize_NewTurn_Returns25**
+  - State of the system: no cards have been purchased yet this game (boundary: full 14 KNIGHT + 6 Progress + 5 VICTORY_POINT deck)
+  - Expected output: `25`
+
+- **TC107: GetRemainingDeckSize_AfterBuyingOneCard_DecreasesByOne**
+  - State of the system: exactly one card has been purchased via `buyDevelopmentCard()` (boundary)
+  - Expected output: `24`
+
 
 

--- a/docs/design/game-first-turn-design.md
+++ b/docs/design/game-first-turn-design.md
@@ -177,12 +177,13 @@ Orchestrates a single player's turn through its three phases. Enforces phase ord
 | `rolledThisTurn`        | `boolean`                            | True once `rollDice()` has been called                                 |
 | `playedDevCardThisTurn` | `boolean`                            | True if a development card has already been played this turn           |
 | `pendingTrade`          | `TradeOffer`                         | The active domestic trade offer, if any; null when no offer is pending |
-| `developmentDeck`       | `List<DevelopmentCard>`              | The shuffled deck of development cards available to buy                |
-| `playerHands`           | `Map<Player, List<DevelopmentCard>>` | Each player's hand of development cards                                |
+| `cardsPurchasedThisTurn`| `List<DevelopmentCard>`              | Cards bought via `buyDevelopmentCard()` this turn (cannot be played the same turn they were purchased) |
+
+The development card deck (`developmentDeck`) and player hands (`playerHands`) are owned by `Game`, not `Turn` — they persist across turns, so `Turn` delegates to `game.drawDevelopmentCard()`, `game.addDevelopmentCardToHand()`, `game.getPlayerHand()`, and `game.getRemainingDevelopmentCardCount()` rather than holding its own copies.
 
 | Method                                                                                                       | Return Type             | Description                                                                                                                                                                                                                                                            |
 |--------------------------------------------------------------------------------------------------------------|-------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `Turn(Game game, Player activePlayer, DiceRoll dice, Bank bank)`                                             | —                       | Constructor; validates no argument is null, sets `phase` to `PRODUCTION`, initializes developmentDeck with 25 shuffled cards (14 KNIGHT, 6 Progress, 5 VICTORY_POINT) and empty hands for all players in the game                                                      |
+| `Turn(Game game, Player activePlayer, DiceRoll dice, Bank bank)`                                             | —                       | Constructor; validates no argument is null, sets `phase` to `PRODUCTION`                                                                                                                                                                                               |
 | `getActivePlayer()`                                                                                          | `Player`                | Returns the player whose turn this is                                                                                                                                                                                                                                  |
 | `getPhase()`                                                                                                 | `TurnPhase`             | Returns the current phase                                                                                                                                                                                                                                              |
 | `rollDice()`                                                                                                 | `int`                   | Calls `dice.roll()`, advances to `TRADE` phase, triggers production or robber logic; throws `IllegalStateException` if called outside `PRODUCTION` phase or called twice                                                                                               |
@@ -213,7 +214,7 @@ Orchestrates a single player's turn through its three phases. Enforces phase ord
 |-------------------------|----------------|------------------------------------------------------------------------------------------------------------------------------------|
 | `enforceDiscard()`      | `void`         | For each player holding > 7 cards, removes `floor(count / 2)` cards at random and returns them to the bank; called internally     |
 | `moveRobber(int hexId)` | `void`         | Moves the robber to the given hex; throws `IllegalArgumentException` if hex is current robber location or id is invalid            |
-| `steal(Player target)`  | `void`         | Steals 1 random resource from `target`; throws if target has no cards or no settlement adjacent to the robber's new hex            |
+| `steal(Player target)`  | `void`         | Steals 1 random resource from `target`; no-op if target holds no resource cards (so the turn cannot get stuck on an empty-handed candidate); throws if `target` has no settlement or city adjacent to the robber's new hex |
 | `getRobbingCandidates()`| `List<Player>` | Returns all players (excluding active player) with a settlement or city adjacent to the hex the robber was just moved to           |
 
 **Phase transition rules:**
@@ -239,7 +240,7 @@ PRODUCTION ──[rollDice()]──► TRADE ──[advanceToBuild()]──► B
 | Settlement placement (road connection)        | Vertex not connected to any player road                               | Vertex at end of at least one player road                 |
 | City upgrade                                  | Vertex not owned by player; vertex has a city already                 | Vertex with player's existing settlement                  |
 | `moveRobber()` target                         | Current robber hex id                                                 | Any other valid hex id                                    |
-| `steal()` target                              | Player with 0 resource cards                                          | Player with 1 resource card                               |
+| `steal()` target resource count               | Player with 0 resource cards (no-op, robber resolves with no transfer)| Player with 1 resource card (transfers that card)         |
 | Build action outside `BUILD` phase            | Any build call during `PRODUCTION` or `TRADE`                         | Any build call during `BUILD`                             |
 | Domestic trade — offerer affords offering     | Offerer has 0 of a resource they're offering                          | Offerer has exactly the amount they're offering           |
 | Domestic trade — recipient affords request    | Recipient has 0 of a resource being requested                         | Recipient has exactly the amount being requested          |

--- a/src/main/java/domain/Board.java
+++ b/src/main/java/domain/Board.java
@@ -6,6 +6,7 @@ public final class Board {
     private final List<Hex> hexes;
     private final List<Vertex> vertices;
     private final List<Edge> edges;
+    private Hex robberHex;
 
     public Board(List<Hex> hexes) {
         validateHexCount(hexes);
@@ -18,6 +19,7 @@ public final class Board {
         this.hexes = new ArrayList<>(hexes);
         this.vertices = new ArrayList<>();
         this.edges = new ArrayList<>();
+        this.robberHex = findDesertHex(this.hexes);
 
         initializeVertices();
         initializeEdges();
@@ -27,6 +29,11 @@ public final class Board {
         this.hexes = new ArrayList<>(hexes);
         this.vertices = new ArrayList<>(vertices);
         this.edges = new ArrayList<>(edges);
+        this.robberHex = findDesertHex(this.hexes);
+    }
+
+    private Hex findDesertHex(List<Hex> hexes) {
+        return hexes.stream().filter(Hex::isDesert).findFirst().orElse(null);
     }
 
     private void validateHexCount(List<Hex> hexes) {
@@ -121,5 +128,19 @@ public final class Board {
 
     public Optional<HarborType> getHarborType(Vertex vertex) {
         return vertex.getHarborType();
+    }
+
+    public Hex getRobberHex() {
+        return robberHex;
+    }
+
+    public void setRobberHex(Hex hex) {
+        if (hex == null) {
+            throw new IllegalArgumentException("Robber hex cannot be null");
+        }
+        if (!hexes.contains(hex)) {
+            throw new IllegalArgumentException("Hex must belong to this board");
+        }
+        this.robberHex = hex;
     }
 }

--- a/src/main/java/domain/Game.java
+++ b/src/main/java/domain/Game.java
@@ -2,7 +2,9 @@ package domain;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 
 /**
@@ -19,6 +21,8 @@ public final class Game {
 
     private final List<Player> players; // Change type to <Player> once PR #17 gets merged
     private final Board board;
+    private final List<DevelopmentCard> developmentDeck;
+    private final Map<Player, List<DevelopmentCard>> playerHands;
 
     // Creates a new Game with the given ordered list of players.
     // Throws NullPointerException if {@code players} is null or contains a null entry
@@ -34,10 +38,64 @@ public final class Game {
 
         this.players = Collections.unmodifiableList(new ArrayList<>(players));
         this.board = board;
+        this.developmentDeck = createShuffledDevelopmentDeck();
+        this.playerHands = createEmptyPlayerHands(this.players);
     }
 
     public List<Player> getPlayers() {
         return players;
+    }
+
+    public int getRemainingDevelopmentCardCount() {
+        return developmentDeck.size();
+    }
+
+    DevelopmentCard drawDevelopmentCard() {
+        if (developmentDeck.isEmpty()) {
+            throw new IllegalStateException("No development cards remain in the deck");
+        }
+        return developmentDeck.remove(developmentDeck.size() - 1);
+    }
+
+    public List<DevelopmentCard> getPlayerHand(Player player) {
+        List<DevelopmentCard> hand = playerHands.get(player);
+        if (hand == null) {
+            throw new IllegalArgumentException("Player is not part of this game");
+        }
+        return Collections.unmodifiableList(hand);
+    }
+
+    void addDevelopmentCardToHand(Player player, DevelopmentCard card) {
+        List<DevelopmentCard> hand = playerHands.get(player);
+        if (hand == null) {
+            throw new IllegalArgumentException("Player is not part of this game");
+        }
+        hand.add(card);
+    }
+
+    private List<DevelopmentCard> createShuffledDevelopmentDeck() {
+        List<DevelopmentCard> deck = new ArrayList<>();
+        for (int i = 0; i < 14; i++) {
+            deck.add(new DevelopmentCard(DevelopmentCardType.KNIGHT));
+        }
+        for (int i = 0; i < 2; i++) {
+            deck.add(new DevelopmentCard(DevelopmentCardType.ROAD_BUILDING));
+            deck.add(new DevelopmentCard(DevelopmentCardType.YEAR_OF_PLENTY));
+            deck.add(new DevelopmentCard(DevelopmentCardType.MONOPOLY));
+        }
+        for (int i = 0; i < 5; i++) {
+            deck.add(new DevelopmentCard(DevelopmentCardType.VICTORY_POINT));
+        }
+        Collections.shuffle(deck);
+        return deck;
+    }
+
+    private Map<Player, List<DevelopmentCard>> createEmptyPlayerHands(List<Player> players) {
+        Map<Player, List<DevelopmentCard>> hands = new HashMap<>();
+        for (Player player : players) {
+            hands.put(player, new ArrayList<>());
+        }
+        return hands;
     }
 
     public int getPlayerCount() {

--- a/src/main/java/domain/ResourceProduction.java
+++ b/src/main/java/domain/ResourceProduction.java
@@ -8,6 +8,10 @@ import java.util.Map;
 public class ResourceProduction {
 
     public void distributeResources(int roll, List<Vertex> vertices, Bank bank) {
+        distributeResources(roll, vertices, null, bank);
+    }
+
+    public void distributeResources(int roll, List<Vertex> vertices, Hex robberHex, Bank bank) {
         if (vertices == null) {
             throw new IllegalArgumentException("Vertices cannot be null");
         }
@@ -19,11 +23,11 @@ public class ResourceProduction {
         }
         Map<ResourceType, Integer> totalNeeded = new EnumMap<>(ResourceType.class);
         Map<Player, Map<ResourceType, Integer>> playerGains = new LinkedHashMap<>();
-        collectGains(roll, vertices, totalNeeded, playerGains);
+        collectGains(roll, vertices, robberHex, totalNeeded, playerGains);
         distributeToPlayers(totalNeeded, playerGains, bank);
     }
 
-    private void collectGains(int roll, List<Vertex> vertices,
+    private void collectGains(int roll, List<Vertex> vertices, Hex robberHex,
             Map<ResourceType, Integer> totalNeeded,
             Map<Player, Map<ResourceType, Integer>> playerGains) {
         for (Vertex vertex : vertices) {
@@ -33,7 +37,7 @@ public class ResourceProduction {
             Player owner = vertex.getOwner().get();
             int amount = vertex.isCity() ? 2 : 1;
             for (Hex hex : vertex.getAdjacentHexes()) {
-                if (hex.getNumberToken() == roll && hex.producesResource()) {
+                if (hex != robberHex && hex.getNumberToken() == roll && hex.producesResource()) {
                     ResourceType resource = hex.getTerrainType().getResourceType();
                     totalNeeded.merge(resource, amount, Integer::sum);
                     playerGains

--- a/src/main/java/domain/SetupPhase.java
+++ b/src/main/java/domain/SetupPhase.java
@@ -4,14 +4,17 @@ import java.util.*;
 
 public class SetupPhase {
     private final Game game;
+    private final Bank bank;
     private final List<Player> placementOrder;
     private int currentPlacementIndex;
     private Vertex lastPlacedSettlement;
     private final Map<Player, List<Vertex>> placedSettlements;
 
-    public SetupPhase(Game game) {
+    public SetupPhase(Game game, Bank bank) {
         validateGame(game);
+        validateBank(bank);
         this.game = game;
+        this.bank = bank;
         this.placementOrder = buildPlacementOrder();
         this.currentPlacementIndex = 0;
         this.lastPlacedSettlement = null;
@@ -85,7 +88,10 @@ public class SetupPhase {
         for (Hex hex : adjacentHexes) {
             if (hex.producesResource()) {
                 ResourceType resource = getResourceFromTerrain(hex.getTerrainType());
-                player.addResources(resource, 1);
+                if (bank.getResourceCount(resource) > 0) {
+                    bank.deduct(resource, 1);
+                    player.addResources(resource, 1);
+                }
             }
         }
     }
@@ -93,6 +99,12 @@ public class SetupPhase {
     private void validateGame(Game game) {
         if (game == null) {
             throw new IllegalArgumentException("Game cannot be null");
+        }
+    }
+
+    private void validateBank(Bank bank) {
+        if (bank == null) {
+            throw new IllegalArgumentException("Bank cannot be null");
         }
     }
 

--- a/src/main/java/domain/Turn.java
+++ b/src/main/java/domain/Turn.java
@@ -173,6 +173,23 @@ public class Turn {
         return candidates;
     }
 
+    public void advanceToBuild() {
+        if (phase != TurnPhase.TRADE) {
+            throw new IllegalStateException("Can only advance to the build phase from the trade phase");
+        }
+        if (robberPendingMove || robberPendingSteal) {
+            throw new IllegalStateException("Robber must be resolved before advancing to the build phase");
+        }
+        phase = TurnPhase.BUILD;
+    }
+
+    public void endTurn() {
+        if (phase != TurnPhase.BUILD) {
+            throw new IllegalStateException("Can only end the turn from the build phase");
+        }
+        phase = TurnPhase.DONE;
+    }
+
     public void buildRoad(int edgeId) {
         buildManager.buildRoad(edgeId);
     }

--- a/src/main/java/domain/Turn.java
+++ b/src/main/java/domain/Turn.java
@@ -191,14 +191,23 @@ public class Turn {
     }
 
     public void buildRoad(int edgeId) {
+        validateInBuildPhase();
         buildManager.buildRoad(edgeId);
     }
 
     public void buildSettlement(int vertexId) {
+        validateInBuildPhase();
         buildManager.buildSettlement(vertexId);
     }
 
     public void buildCity(int vertexId) {
+        validateInBuildPhase();
         buildManager.buildCity(vertexId);
+    }
+
+    private void validateInBuildPhase() {
+        if (phase != TurnPhase.BUILD) {
+            throw new IllegalStateException("Build actions are only allowed during the build phase");
+        }
     }
 }

--- a/src/main/java/domain/Turn.java
+++ b/src/main/java/domain/Turn.java
@@ -11,7 +11,9 @@ public class Turn {
     private TurnPhase phase;
     private boolean rolledThisTurn;
     private boolean playedDevCardThisTurn;
+    private int lastRoll;
     private final BuildManager buildManager;
+    private final ResourceProduction resourceProduction;
 
     Turn(Game game, Player activePlayer, DiceRoll dice, Bank bank) {
         validateGame(game);
@@ -25,6 +27,7 @@ public class Turn {
         this.bank = bank;
         this.phase = TurnPhase.PRODUCTION;
         this.buildManager = new BuildManager(game, activePlayer, bank);
+        this.resourceProduction = new ResourceProduction();
     }
 
     private void validateGame(Game game) {
@@ -53,6 +56,35 @@ public class Turn {
 
     public TurnPhase getPhase() {
         return this.phase;
+    }
+
+    public int rollDice() {
+        validateCanRoll();
+
+        int roll = dice.roll();
+        rolledThisTurn = true;
+        lastRoll = roll;
+
+        if (roll != 7) {
+            produceResources(roll);
+        }
+
+        phase = TurnPhase.TRADE;
+        return roll;
+    }
+
+    public boolean isSevenRolled() {
+        return rolledThisTurn && lastRoll == 7;
+    }
+
+    private void validateCanRoll() {
+        if (phase != TurnPhase.PRODUCTION || rolledThisTurn) {
+            throw new IllegalStateException("Dice can only be rolled once, at the start of a turn");
+        }
+    }
+
+    private void produceResources(int roll) {
+        resourceProduction.distributeResources(roll, game.getBoard().getVertices(), bank);
     }
 
     public void buildRoad(int edgeId) {

--- a/src/main/java/domain/Turn.java
+++ b/src/main/java/domain/Turn.java
@@ -1,5 +1,6 @@
 package domain;
 
+import java.util.ArrayList;
 import java.util.List;
 
 public class Turn {
@@ -12,6 +13,8 @@ public class Turn {
     private boolean rolledThisTurn;
     private boolean playedDevCardThisTurn;
     private int lastRoll;
+    private boolean robberPendingMove;
+    private boolean robberPendingSteal;
     private final BuildManager buildManager;
     private final ResourceProduction resourceProduction;
 
@@ -67,6 +70,9 @@ public class Turn {
 
         if (roll != 7) {
             produceResources(roll);
+        } else {
+            enforceDiscard();
+            robberPendingMove = true;
         }
 
         phase = TurnPhase.TRADE;
@@ -85,6 +91,86 @@ public class Turn {
 
     private void produceResources(int roll) {
         resourceProduction.distributeResources(roll, game.getBoard().getVertices(), bank);
+    }
+
+    private void enforceDiscard() {
+        for (Player player : game.getPlayers()) {
+            int total = player.getTotalResourceCount();
+            if (total > 7) {
+                discardHalf(player, total / 2);
+            }
+        }
+    }
+
+    private void discardHalf(Player player, int amount) {
+        int remaining = amount;
+        for (ResourceType type : ResourceType.values()) {
+            int toRemove = Math.min(player.getResourceCount(type), remaining);
+            if (toRemove > 0) {
+                player.removeResources(type, toRemove);
+                bank.collect(type, toRemove);
+                remaining -= toRemove;
+            }
+        }
+    }
+
+    public void moveRobber(int hexId) {
+        if (!robberPendingMove) {
+            throw new IllegalStateException("Robber can only be moved immediately after rolling a 7");
+        }
+
+        Board board = game.getBoard();
+        List<Hex> hexes = board.getHexes();
+        if (hexId < 0 || hexId >= hexes.size()) {
+            throw new IllegalArgumentException("Invalid hex id: " + hexId);
+        }
+
+        Hex target = hexes.get(hexId);
+        if (target == board.getRobberHex()) {
+            throw new IllegalArgumentException("Robber is already on that hex");
+        }
+
+        board.setRobberHex(target);
+        robberPendingMove = false;
+        robberPendingSteal = !getRobbingCandidates().isEmpty();
+    }
+
+    public void steal(Player target) {
+        if (!robberPendingSteal) {
+            throw new IllegalStateException("Stealing is only allowed immediately after moving the robber onto a hex with eligible targets");
+        }
+        if (!getRobbingCandidates().contains(target)) {
+            throw new IllegalArgumentException("Target must have a settlement or city adjacent to the robber's hex");
+        }
+
+        ResourceType stolen = pickResourceToSteal(target);
+        target.removeResources(stolen, 1);
+        activePlayer.addResources(stolen, 1);
+        robberPendingSteal = false;
+    }
+
+    private ResourceType pickResourceToSteal(Player target) {
+        for (ResourceType type : ResourceType.values()) {
+            if (target.getResourceCount(type) > 0) {
+                return type;
+            }
+        }
+        throw new IllegalStateException("Target has no resource cards to steal");
+    }
+
+    public List<Player> getRobbingCandidates() {
+        Hex robberHex = game.getBoard().getRobberHex();
+        List<Player> candidates = new ArrayList<>();
+        for (Vertex vertex : game.getBoard().getVertices()) {
+            vertex.getOwner().ifPresent(owner -> {
+                if (owner != activePlayer
+                        && vertex.getAdjacentHexes().contains(robberHex)
+                        && !candidates.contains(owner)) {
+                    candidates.add(owner);
+                }
+            });
+        }
+        return candidates;
     }
 
     public void buildRoad(int edgeId) {

--- a/src/main/java/domain/Turn.java
+++ b/src/main/java/domain/Turn.java
@@ -281,4 +281,23 @@ public class Turn {
             to.addResources(entry.getKey(), entry.getValue());
         }
     }
+
+    public void submitMaritimeTrade(MaritimeTrade trade) {
+        if (phase != TurnPhase.TRADE) {
+            throw new IllegalStateException("Maritime trades can only be submitted during the trade phase");
+        }
+        if (bank.getResourceCount(trade.getReceiving()) < 1) {
+            throw new IllegalStateException("Bank has none of the requested resource");
+        }
+
+        Player player = trade.getPlayer();
+        ResourceType giving = trade.getGiving();
+        ResourceType receiving = trade.getReceiving();
+        int amount = trade.getAmount();
+
+        player.removeResources(giving, amount);
+        bank.collect(giving, amount);
+        bank.deduct(receiving, 1);
+        player.addResources(receiving, 1);
+    }
 }

--- a/src/main/java/domain/Turn.java
+++ b/src/main/java/domain/Turn.java
@@ -2,12 +2,15 @@ package domain;
 
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Random;
 
 public class Turn {
+
+    private static final Map<ResourceType, Integer> DEVELOPMENT_CARD_COST = Map.of(
+            ResourceType.ORE, 1, ResourceType.WOOL, 1, ResourceType.GRAIN, 1);
 
     private final Game game;
     private final Player activePlayer;
@@ -19,54 +22,32 @@ public class Turn {
     private int lastRoll;
     private boolean robberPendingMove;
     private boolean robberPendingSteal;
+    private final Random random;
     private final BuildManager buildManager;
     private final ResourceProduction resourceProduction;
     private TradeOffer pendingTrade;
-    private final List<DevelopmentCard> developmentDeck;
-    private final Map<Player, List<DevelopmentCard>> playerHands;
     private final List<DevelopmentCard> cardsPurchasedThisTurn;
 
     Turn(Game game, Player activePlayer, DiceRoll dice, Bank bank) {
+        this(game, activePlayer, dice, bank, new Random());
+    }
+
+    Turn(Game game, Player activePlayer, DiceRoll dice, Bank bank, Random random) {
         validateGame(game);
         validatePlayer(activePlayer);
         validateDice(dice);
         validateBank(bank);
+        validateRandom(random);
 
         this.game = game;
         this.activePlayer = activePlayer;
         this.dice = dice;
         this.bank = bank;
+        this.random = random;
         this.phase = TurnPhase.PRODUCTION;
         this.buildManager = new BuildManager(game, activePlayer, bank);
         this.resourceProduction = new ResourceProduction();
-        this.developmentDeck = createShuffledDevelopmentDeck();
-        this.playerHands = createEmptyPlayerHands(game);
         this.cardsPurchasedThisTurn = new ArrayList<>();
-    }
-
-    private List<DevelopmentCard> createShuffledDevelopmentDeck() {
-        List<DevelopmentCard> deck = new ArrayList<>();
-        for (int i = 0; i < 14; i++) {
-            deck.add(new DevelopmentCard(DevelopmentCardType.KNIGHT));
-        }
-        for (int i = 0; i < 2; i++) {
-            deck.add(new DevelopmentCard(DevelopmentCardType.ROAD_BUILDING));
-            deck.add(new DevelopmentCard(DevelopmentCardType.YEAR_OF_PLENTY));
-            deck.add(new DevelopmentCard(DevelopmentCardType.MONOPOLY));
-        }
-        for (int i = 0; i < 5; i++) {
-            deck.add(new DevelopmentCard(DevelopmentCardType.VICTORY_POINT));
-        }
-        Collections.shuffle(deck);
-        return deck;
-    }
-
-    private Map<Player, List<DevelopmentCard>> createEmptyPlayerHands(Game game) {
-        Map<Player, List<DevelopmentCard>> hands = new HashMap<>();
-        for (Player player : game.getPlayers()) {
-            hands.put(player, new ArrayList<>());
-        }
-        return hands;
     }
 
     private void validateGame(Game game) {
@@ -90,6 +71,12 @@ public class Turn {
     private void validateBank(Bank bank) {
         if (bank == null) {
             throw new IllegalArgumentException("Bank cannot be null");
+        }
+    }
+
+    private void validateRandom(Random random) {
+        if (random == null) {
+            throw new IllegalArgumentException("Random cannot be null");
         }
     }
 
@@ -126,7 +113,8 @@ public class Turn {
     }
 
     private void produceResources(int roll) {
-        resourceProduction.distributeResources(roll, game.getBoard().getVertices(), bank);
+        Board board = game.getBoard();
+        resourceProduction.distributeResources(roll, board.getVertices(), board.getRobberHex(), bank);
     }
 
     private void enforceDiscard() {
@@ -139,14 +127,12 @@ public class Turn {
     }
 
     private void discardHalf(Player player, int amount) {
-        int remaining = amount;
-        for (ResourceType type : ResourceType.values()) {
-            int toRemove = Math.min(player.getResourceCount(type), remaining);
-            if (toRemove > 0) {
-                player.removeResources(type, toRemove);
-                bank.collect(type, toRemove);
-                remaining -= toRemove;
-            }
+        List<ResourceType> heldCards = expandHeldResources(player);
+        Collections.shuffle(heldCards, random);
+        for (int i = 0; i < amount; i++) {
+            ResourceType type = heldCards.get(i);
+            player.removeResources(type, 1);
+            bank.collect(type, 1);
         }
     }
 
@@ -179,19 +165,27 @@ public class Turn {
             throw new IllegalArgumentException("Target must have a settlement or city adjacent to the robber's hex");
         }
 
-        ResourceType stolen = pickResourceToSteal(target);
-        target.removeResources(stolen, 1);
-        activePlayer.addResources(stolen, 1);
+        if (target.getTotalResourceCount() > 0) {
+            ResourceType stolen = pickResourceToSteal(target);
+            target.removeResources(stolen, 1);
+            activePlayer.addResources(stolen, 1);
+        }
         robberPendingSteal = false;
     }
 
     private ResourceType pickResourceToSteal(Player target) {
+        List<ResourceType> heldCards = expandHeldResources(target);
+        return heldCards.get(random.nextInt(heldCards.size()));
+    }
+
+    private List<ResourceType> expandHeldResources(Player player) {
+        List<ResourceType> cards = new ArrayList<>();
         for (ResourceType type : ResourceType.values()) {
-            if (target.getResourceCount(type) > 0) {
-                return type;
+            for (int i = 0; i < player.getResourceCount(type); i++) {
+                cards.add(type);
             }
         }
-        throw new IllegalStateException("Target has no resource cards to steal");
+        return cards;
     }
 
     public List<Player> getRobbingCandidates() {
@@ -213,10 +207,29 @@ public class Turn {
         if (phase != TurnPhase.TRADE) {
             throw new IllegalStateException("Can only advance to the build phase from the trade phase");
         }
-        if (robberPendingMove || robberPendingSteal) {
-            throw new IllegalStateException("Robber must be resolved before advancing to the build phase");
-        }
+        validateRobberResolved();
+        expirePendingTrade();
         phase = TurnPhase.BUILD;
+    }
+
+    private void expirePendingTrade() {
+        if (pendingTrade != null) {
+            pendingTrade.reject();
+            pendingTrade = null;
+        }
+    }
+
+    private void validateRobberResolved() {
+        if (robberPendingMove || robberPendingSteal) {
+            throw new IllegalStateException("Robber must be resolved before performing this action");
+        }
+    }
+
+    private void validateInTradePhase(String wrongPhaseMessage) {
+        if (phase != TurnPhase.TRADE) {
+            throw new IllegalStateException(wrongPhaseMessage);
+        }
+        validateRobberResolved();
     }
 
     public void endTurn() {
@@ -248,9 +261,8 @@ public class Turn {
     }
 
     public TradeOffer proposeTrade(Player recipient, Map<ResourceType, Integer> offering, Map<ResourceType, Integer> requesting) {
-        if (phase != TurnPhase.TRADE) {
-            throw new IllegalStateException("Trades can only be proposed during the trade phase");
-        }
+        validateInTradePhase("Trades can only be proposed during the trade phase");
+        validateRecipientInGame(recipient);
         if (pendingTrade != null) {
             throw new IllegalStateException("A trade offer is already pending");
         }
@@ -262,6 +274,7 @@ public class Turn {
     }
 
     public void acceptTrade(TradeOffer offer) {
+        validateInTradePhase("Trades can only be accepted during the trade phase");
         validateMatchesPendingTrade(offer);
 
         Player offerer = offer.getOfferer();
@@ -277,6 +290,7 @@ public class Turn {
     }
 
     public void rejectTrade(TradeOffer offer) {
+        validateInTradePhase("Trades can only be rejected during the trade phase");
         validateMatchesPendingTrade(offer);
         offer.reject();
         pendingTrade = null;
@@ -286,6 +300,12 @@ public class Turn {
         return Optional.ofNullable(pendingTrade);
     }
 
+    private void validateRecipientInGame(Player recipient) {
+        if (recipient == null || !game.getPlayers().contains(recipient)) {
+            throw new IllegalArgumentException("Recipient must be another player in this game");
+        }
+    }
+
     private void validateMatchesPendingTrade(TradeOffer offer) {
         if (pendingTrade == null || offer != pendingTrade) {
             throw new IllegalStateException("There is no matching pending trade offer");
@@ -293,19 +313,24 @@ public class Turn {
     }
 
     private void validateOffererCanAffordOffering(Map<ResourceType, Integer> offering) {
-        for (Map.Entry<ResourceType, Integer> entry : offering.entrySet()) {
-            if (activePlayer.getResourceCount(entry.getKey()) < entry.getValue()) {
-                throw new IllegalArgumentException("Active player cannot afford the offered resources");
-            }
+        if (!canAfford(activePlayer, offering)) {
+            throw new IllegalArgumentException("Active player cannot afford the offered resources");
         }
     }
 
     private void validateCanAffordTrade(Player player, Map<ResourceType, Integer> resources) {
+        if (!canAfford(player, resources)) {
+            throw new IllegalStateException("Player cannot afford this trade");
+        }
+    }
+
+    private boolean canAfford(Player player, Map<ResourceType, Integer> resources) {
         for (Map.Entry<ResourceType, Integer> entry : resources.entrySet()) {
             if (player.getResourceCount(entry.getKey()) < entry.getValue()) {
-                throw new IllegalStateException("Player cannot afford this trade");
+                return false;
             }
         }
+        return true;
     }
 
     private void exchange(Player from, Player to, Map<ResourceType, Integer> resources) {
@@ -316,8 +341,9 @@ public class Turn {
     }
 
     public void submitMaritimeTrade(MaritimeTrade trade) {
-        if (phase != TurnPhase.TRADE) {
-            throw new IllegalStateException("Maritime trades can only be submitted during the trade phase");
+        validateInTradePhase("Maritime trades can only be submitted during the trade phase");
+        if (trade.getPlayer() != activePlayer) {
+            throw new IllegalArgumentException("Maritime trades can only be submitted by the active player");
         }
         if (bank.getResourceCount(trade.getReceiving()) < 1) {
             throw new IllegalStateException("Bank has none of the requested resource");
@@ -335,35 +361,45 @@ public class Turn {
     }
 
     public void buyDevelopmentCard() {
-        if (phase != TurnPhase.BUILD) {
-            throw new IllegalStateException("Development cards can only be bought during the build phase");
-        }
-        if (activePlayer.getResourceCount(ResourceType.ORE) < 1
-                || activePlayer.getResourceCount(ResourceType.WOOL) < 1
-                || activePlayer.getResourceCount(ResourceType.GRAIN) < 1) {
+        validateInBuildPhase();
+        if (!canAfford(activePlayer, DEVELOPMENT_CARD_COST)) {
             throw new IllegalStateException("Active player cannot afford a development card");
         }
-        if (developmentDeck.isEmpty()) {
+        if (game.getRemainingDevelopmentCardCount() == 0) {
             throw new IllegalStateException("No development cards remain in the deck");
         }
 
-        activePlayer.removeResources(ResourceType.ORE, 1);
-        activePlayer.removeResources(ResourceType.WOOL, 1);
-        activePlayer.removeResources(ResourceType.GRAIN, 1);
+        for (Map.Entry<ResourceType, Integer> entry : DEVELOPMENT_CARD_COST.entrySet()) {
+            activePlayer.removeResources(entry.getKey(), entry.getValue());
+            bank.collect(entry.getKey(), entry.getValue());
+        }
 
-        DevelopmentCard card = developmentDeck.remove(developmentDeck.size() - 1);
-        playerHands.get(activePlayer).add(card);
+        DevelopmentCard card = game.drawDevelopmentCard();
+        game.addDevelopmentCardToHand(activePlayer, card);
         cardsPurchasedThisTurn.add(card);
     }
 
     public void playDevelopmentCard(Player player, DevelopmentCard card) {
+        if (card == null) {
+            throw new IllegalArgumentException("Development card cannot be null");
+        }
+        if (player != activePlayer) {
+            throw new IllegalArgumentException("Only the active player can play a development card");
+        }
         if (phase != TurnPhase.TRADE && phase != TurnPhase.BUILD) {
             throw new IllegalStateException("Development cards can only be played during the trade or build phase");
+        }
+        validateRobberResolved();
+        if (card.getType() == DevelopmentCardType.VICTORY_POINT) {
+            throw new IllegalStateException("Victory Point cards cannot be played");
         }
         if (playedDevCardThisTurn) {
             throw new IllegalStateException("Only one development card can be played per turn");
         }
-        if (cardsPurchasedThisTurn.contains(card) && card.getType() != DevelopmentCardType.VICTORY_POINT) {
+        if (!game.getPlayerHand(player).contains(card)) {
+            throw new IllegalArgumentException("Player does not own this development card");
+        }
+        if (cardsPurchasedThisTurn.contains(card)) {
             throw new IllegalStateException("A development card cannot be played the same turn it was purchased");
         }
         if (card.isPlayed()) {
@@ -375,10 +411,10 @@ public class Turn {
     }
 
     public List<DevelopmentCard> getPlayerHand(Player player) {
-        return Collections.unmodifiableList(playerHands.get(player));
+        return game.getPlayerHand(player);
     }
 
     public int getRemainingDeckSize() {
-        return developmentDeck.size();
+        return game.getRemainingDevelopmentCardCount();
     }
 }

--- a/src/main/java/domain/Turn.java
+++ b/src/main/java/domain/Turn.java
@@ -2,6 +2,8 @@ package domain;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 
 public class Turn {
 
@@ -17,6 +19,7 @@ public class Turn {
     private boolean robberPendingSteal;
     private final BuildManager buildManager;
     private final ResourceProduction resourceProduction;
+    private TradeOffer pendingTrade;
 
     Turn(Game game, Player activePlayer, DiceRoll dice, Bank bank) {
         validateGame(game);
@@ -208,6 +211,74 @@ public class Turn {
     private void validateInBuildPhase() {
         if (phase != TurnPhase.BUILD) {
             throw new IllegalStateException("Build actions are only allowed during the build phase");
+        }
+    }
+
+    public TradeOffer proposeTrade(Player recipient, Map<ResourceType, Integer> offering, Map<ResourceType, Integer> requesting) {
+        if (phase != TurnPhase.TRADE) {
+            throw new IllegalStateException("Trades can only be proposed during the trade phase");
+        }
+        if (pendingTrade != null) {
+            throw new IllegalStateException("A trade offer is already pending");
+        }
+
+        TradeOffer offer = new TradeOffer(activePlayer, recipient, offering, requesting);
+        validateOffererCanAffordOffering(offer.getOffering());
+        pendingTrade = offer;
+        return offer;
+    }
+
+    public void acceptTrade(TradeOffer offer) {
+        validateMatchesPendingTrade(offer);
+
+        Player offerer = offer.getOfferer();
+        Player recipient = offer.getRecipient();
+        validateCanAffordTrade(offerer, offer.getOffering());
+        validateCanAffordTrade(recipient, offer.getRequesting());
+
+        exchange(offerer, recipient, offer.getOffering());
+        exchange(recipient, offerer, offer.getRequesting());
+
+        offer.accept();
+        pendingTrade = null;
+    }
+
+    public void rejectTrade(TradeOffer offer) {
+        validateMatchesPendingTrade(offer);
+        offer.reject();
+        pendingTrade = null;
+    }
+
+    public Optional<TradeOffer> getPendingTrade() {
+        return Optional.ofNullable(pendingTrade);
+    }
+
+    private void validateMatchesPendingTrade(TradeOffer offer) {
+        if (pendingTrade == null || offer != pendingTrade) {
+            throw new IllegalStateException("There is no matching pending trade offer");
+        }
+    }
+
+    private void validateOffererCanAffordOffering(Map<ResourceType, Integer> offering) {
+        for (Map.Entry<ResourceType, Integer> entry : offering.entrySet()) {
+            if (activePlayer.getResourceCount(entry.getKey()) < entry.getValue()) {
+                throw new IllegalArgumentException("Active player cannot afford the offered resources");
+            }
+        }
+    }
+
+    private void validateCanAffordTrade(Player player, Map<ResourceType, Integer> resources) {
+        for (Map.Entry<ResourceType, Integer> entry : resources.entrySet()) {
+            if (player.getResourceCount(entry.getKey()) < entry.getValue()) {
+                throw new IllegalStateException("Player cannot afford this trade");
+            }
+        }
+    }
+
+    private void exchange(Player from, Player to, Map<ResourceType, Integer> resources) {
+        for (Map.Entry<ResourceType, Integer> entry : resources.entrySet()) {
+            from.removeResources(entry.getKey(), entry.getValue());
+            to.addResources(entry.getKey(), entry.getValue());
         }
     }
 }

--- a/src/main/java/domain/Turn.java
+++ b/src/main/java/domain/Turn.java
@@ -1,6 +1,8 @@
 package domain;
 
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -20,6 +22,9 @@ public class Turn {
     private final BuildManager buildManager;
     private final ResourceProduction resourceProduction;
     private TradeOffer pendingTrade;
+    private final List<DevelopmentCard> developmentDeck;
+    private final Map<Player, List<DevelopmentCard>> playerHands;
+    private final List<DevelopmentCard> cardsPurchasedThisTurn;
 
     Turn(Game game, Player activePlayer, DiceRoll dice, Bank bank) {
         validateGame(game);
@@ -34,6 +39,34 @@ public class Turn {
         this.phase = TurnPhase.PRODUCTION;
         this.buildManager = new BuildManager(game, activePlayer, bank);
         this.resourceProduction = new ResourceProduction();
+        this.developmentDeck = createShuffledDevelopmentDeck();
+        this.playerHands = createEmptyPlayerHands(game);
+        this.cardsPurchasedThisTurn = new ArrayList<>();
+    }
+
+    private List<DevelopmentCard> createShuffledDevelopmentDeck() {
+        List<DevelopmentCard> deck = new ArrayList<>();
+        for (int i = 0; i < 14; i++) {
+            deck.add(new DevelopmentCard(DevelopmentCardType.KNIGHT));
+        }
+        for (int i = 0; i < 2; i++) {
+            deck.add(new DevelopmentCard(DevelopmentCardType.ROAD_BUILDING));
+            deck.add(new DevelopmentCard(DevelopmentCardType.YEAR_OF_PLENTY));
+            deck.add(new DevelopmentCard(DevelopmentCardType.MONOPOLY));
+        }
+        for (int i = 0; i < 5; i++) {
+            deck.add(new DevelopmentCard(DevelopmentCardType.VICTORY_POINT));
+        }
+        Collections.shuffle(deck);
+        return deck;
+    }
+
+    private Map<Player, List<DevelopmentCard>> createEmptyPlayerHands(Game game) {
+        Map<Player, List<DevelopmentCard>> hands = new HashMap<>();
+        for (Player player : game.getPlayers()) {
+            hands.put(player, new ArrayList<>());
+        }
+        return hands;
     }
 
     private void validateGame(Game game) {
@@ -299,5 +332,53 @@ public class Turn {
         bank.collect(giving, amount);
         bank.deduct(receiving, 1);
         player.addResources(receiving, 1);
+    }
+
+    public void buyDevelopmentCard() {
+        if (phase != TurnPhase.BUILD) {
+            throw new IllegalStateException("Development cards can only be bought during the build phase");
+        }
+        if (activePlayer.getResourceCount(ResourceType.ORE) < 1
+                || activePlayer.getResourceCount(ResourceType.WOOL) < 1
+                || activePlayer.getResourceCount(ResourceType.GRAIN) < 1) {
+            throw new IllegalStateException("Active player cannot afford a development card");
+        }
+        if (developmentDeck.isEmpty()) {
+            throw new IllegalStateException("No development cards remain in the deck");
+        }
+
+        activePlayer.removeResources(ResourceType.ORE, 1);
+        activePlayer.removeResources(ResourceType.WOOL, 1);
+        activePlayer.removeResources(ResourceType.GRAIN, 1);
+
+        DevelopmentCard card = developmentDeck.remove(developmentDeck.size() - 1);
+        playerHands.get(activePlayer).add(card);
+        cardsPurchasedThisTurn.add(card);
+    }
+
+    public void playDevelopmentCard(Player player, DevelopmentCard card) {
+        if (phase != TurnPhase.TRADE && phase != TurnPhase.BUILD) {
+            throw new IllegalStateException("Development cards can only be played during the trade or build phase");
+        }
+        if (playedDevCardThisTurn) {
+            throw new IllegalStateException("Only one development card can be played per turn");
+        }
+        if (cardsPurchasedThisTurn.contains(card) && card.getType() != DevelopmentCardType.VICTORY_POINT) {
+            throw new IllegalStateException("A development card cannot be played the same turn it was purchased");
+        }
+        if (card.isPlayed()) {
+            throw new IllegalStateException("This development card has already been played");
+        }
+
+        card.markAsPlayed();
+        playedDevCardThisTurn = true;
+    }
+
+    public List<DevelopmentCard> getPlayerHand(Player player) {
+        return Collections.unmodifiableList(playerHands.get(player));
+    }
+
+    public int getRemainingDeckSize() {
+        return developmentDeck.size();
     }
 }

--- a/src/test/java/domain/BankTest.java
+++ b/src/test/java/domain/BankTest.java
@@ -79,6 +79,18 @@ public class BankTest {
     }
 
     @Test
+    void Collect_WithNullType_ThrowsIllegalArgumentException() {
+        Bank bank = new Bank();
+        assertThrows(IllegalArgumentException.class, () -> bank.collect(null, 1));
+    }
+
+    @Test
+    void Collect_WithNegativeAmount_ThrowsIllegalArgumentException() {
+        Bank bank = new Bank();
+        assertThrows(IllegalArgumentException.class, () -> bank.collect(ResourceType.BRICK, -1));
+    }
+
+    @Test
     void Collect_WithAmountZero_NoChange() {
         Bank bank = bankWithBrick(5);
         bank.collect(ResourceType.BRICK, 0);

--- a/src/test/java/domain/BoardTest.java
+++ b/src/test/java/domain/BoardTest.java
@@ -388,4 +388,30 @@ public class BoardTest {
     void getHarborType_ForLumberHarborVertex_ReturnsLumber() {
         assertEquals(HarborType.LUMBER, board.getHarborType(board.getVertex(11)).orElseThrow());
     }
+
+    @Test
+    void getRobberHex_NewBoard_StartsOnDesertHex() {
+        assertEquals(TerrainType.DESERT, board.getRobberHex().getTerrainType());
+    }
+
+    @Test
+    void setRobberHex_WithNull_ThrowsIllegalArgumentException() {
+        assertThrows(IllegalArgumentException.class, () -> board.setRobberHex(null));
+    }
+
+    @Test
+    void setRobberHex_WithHexNotOnBoard_ThrowsIllegalArgumentException() {
+        Hex foreignHex = new Hex(TerrainType.HILLS, 6);
+
+        assertThrows(IllegalArgumentException.class, () -> board.setRobberHex(foreignHex));
+    }
+
+    @Test
+    void setRobberHex_WithHexOnBoard_UpdatesRobberHex() {
+        Hex target = board.getHexes().get(1);
+
+        board.setRobberHex(target);
+
+        assertEquals(target, board.getRobberHex());
+    }
 }

--- a/src/test/java/domain/BoardTest.java
+++ b/src/test/java/domain/BoardTest.java
@@ -196,6 +196,21 @@ public class BoardTest {
     }
 
     @Test
+    void Constructor_OnValidBoard_PopulatesAdjacentVerticesForEveryVertex() {
+        List<Vertex> adjacentVertices = board.getVertex(0).getAdjacentVertices();
+        List<Integer> adjacentIds = new ArrayList<>();
+        for (Vertex vertex : adjacentVertices) {
+            adjacentIds.add(vertex.getId());
+        }
+
+        assertAll(
+                () -> assertEquals(2, adjacentVertices.size()),
+                () -> assertTrue(adjacentIds.contains(3)),
+                () -> assertTrue(adjacentIds.contains(4))
+        );
+    }
+
+    @Test
     void GetEdges_OnValidBoard_Returns72Edges() {
         assertEquals(72, board.getEdges().size());
     }

--- a/src/test/java/domain/GameTest.java
+++ b/src/test/java/domain/GameTest.java
@@ -211,4 +211,65 @@ public class GameTest {
         assertDoesNotThrow(() -> new Game(Arrays.asList(alice, bob, charlie, diana), board));
     }
 
+    //
+    // Development card deck and player hands
+    //
+
+    @Test
+    void getRemainingDevelopmentCardCount_newGame_returnsTwentyFive() {
+        Game game = new Game(Arrays.asList(alice, bob), board);
+        assertEquals(25, game.getRemainingDevelopmentCardCount());
+    }
+
+    @Test
+    void drawDevelopmentCard_removesCardFromDeck_decrementsRemainingCount() {
+        Game game = new Game(Arrays.asList(alice, bob), board);
+        int before = game.getRemainingDevelopmentCardCount();
+
+        DevelopmentCard card = game.drawDevelopmentCard();
+
+        assertNotNull(card);
+        assertEquals(before - 1, game.getRemainingDevelopmentCardCount());
+    }
+
+    @Test
+    void drawDevelopmentCard_emptyDeck_throwsIllegalState() {
+        Game game = new Game(Arrays.asList(alice, bob), board);
+        for (int i = 0; i < 25; i++) {
+            game.drawDevelopmentCard();
+        }
+
+        assertThrows(IllegalStateException.class, game::drawDevelopmentCard);
+    }
+
+    @Test
+    void getPlayerHand_newGame_returnsEmptyHand() {
+        Game game = new Game(Arrays.asList(alice, bob), board);
+        assertTrue(game.getPlayerHand(alice).isEmpty());
+    }
+
+    @Test
+    void getPlayerHand_playerNotInGame_throwsIllegalArgument() {
+        Game game = new Game(Arrays.asList(alice, bob), board);
+        assertThrows(IllegalArgumentException.class, () -> game.getPlayerHand(charlie));
+    }
+
+    @Test
+    void addDevelopmentCardToHand_addsCardToPlayersHand() {
+        Game game = new Game(Arrays.asList(alice, bob), board);
+        DevelopmentCard card = game.drawDevelopmentCard();
+
+        game.addDevelopmentCardToHand(alice, card);
+
+        assertEquals(List.of(card), game.getPlayerHand(alice));
+    }
+
+    @Test
+    void addDevelopmentCardToHand_playerNotInGame_throwsIllegalArgument() {
+        Game game = new Game(Arrays.asList(alice, bob), board);
+        DevelopmentCard card = game.drawDevelopmentCard();
+
+        assertThrows(IllegalArgumentException.class, () -> game.addDevelopmentCardToHand(charlie, card));
+    }
+
 }

--- a/src/test/java/domain/ResourceProductionTest.java
+++ b/src/test/java/domain/ResourceProductionTest.java
@@ -81,6 +81,32 @@ public class ResourceProductionTest {
     }
 
     @Test
+    void DistributeResources_HexHasRobber_NoResourceDistributedFromThatHex() {
+        Player player = new Player("Alice", PlayerColor.RED);
+        Hex hex = new Hex(TerrainType.HILLS, 6);
+        Vertex vertex = settledVertex(0, player, List.of(hex));
+        Bank bank = bankWith(ResourceType.BRICK, 19);
+
+        new ResourceProduction().distributeResources(6, List.of(vertex), hex, bank);
+
+        assertEquals(0, player.getResourceCount(ResourceType.BRICK));
+        assertEquals(19, bank.getResourceCount(ResourceType.BRICK));
+    }
+
+    @Test
+    void DistributeResources_RobberOnDifferentHex_StillDistributes() {
+        Player player = new Player("Alice", PlayerColor.RED);
+        Hex hex = new Hex(TerrainType.HILLS, 6);
+        Hex robbedHex = new Hex(TerrainType.MOUNTAINS, 6);
+        Vertex vertex = settledVertex(0, player, List.of(hex));
+        Bank bank = bankWith(ResourceType.BRICK, 19);
+
+        new ResourceProduction().distributeResources(6, List.of(vertex), robbedHex, bank);
+
+        assertEquals(1, player.getResourceCount(ResourceType.BRICK));
+    }
+
+    @Test
     void DistributeResources_BankHas0_NoOneReceives() {
         Player player = new Player("Alice", PlayerColor.RED);
         Hex hex = new Hex(TerrainType.HILLS, 6);

--- a/src/test/java/domain/SetupPhaseTest.java
+++ b/src/test/java/domain/SetupPhaseTest.java
@@ -14,6 +14,7 @@ public class SetupPhaseTest {
     private Player p1, p2, p3, p4;
     private Game game2Players;
     private Game game4Players;
+    private Bank bank;
     private SetupPhase phase2;
     private SetupPhase phase4;
 
@@ -62,21 +63,29 @@ public class SetupPhaseTest {
 
         game2Players = new Game(players2, board);
         game4Players = new Game(players4, board);
+        bank = new Bank();
 
-        phase2 = new SetupPhase(game2Players);
-        phase4 = new SetupPhase(game4Players);
+        phase2 = new SetupPhase(game2Players, bank);
+        phase4 = new SetupPhase(game4Players, bank);
     }
 
     @Test
     public void constructor_nullGame_throwsIllegalArgument() {
         Game game = null;
 
-        assertThrows(IllegalArgumentException.class, () -> new SetupPhase(game));
+        assertThrows(IllegalArgumentException.class, () -> new SetupPhase(game, bank));
+    }
+
+    @Test
+    public void constructor_nullBank_throwsIllegalArgument() {
+        Bank nullBank = null;
+
+        assertThrows(IllegalArgumentException.class, () -> new SetupPhase(game2Players, nullBank));
     }
 
     @Test
     public void constructor_validGame_2Players_buildsCorrectPlacementOrder() {
-        SetupPhase phase = new SetupPhase(game2Players);
+        SetupPhase phase = new SetupPhase(game2Players, bank);
 
         List<Player> expectedOrder = Arrays.asList(p1, p2, p2, p1);
         assertEquals(expectedOrder, phase.getPlacementOrder());

--- a/src/test/java/domain/TurnTest.java
+++ b/src/test/java/domain/TurnTest.java
@@ -204,6 +204,201 @@ public class TurnTest {
         assertFalse(turn.isSevenRolled());
     }
 
+    private Vertex findVertexAdjacentToHex(Hex hex) {
+        for (Vertex vertex : board.getVertices()) {
+            if (vertex.getAdjacentHexes().contains(hex)) {
+                return vertex;
+            }
+        }
+        throw new IllegalStateException("No vertex found adjacent to the given hex");
+    }
+
+    private Hex findNonDesertHex() {
+        for (Hex hex : board.getHexes()) {
+            if (!hex.isDesert()) {
+                return hex;
+            }
+        }
+        throw new IllegalStateException("No non-desert hex found");
+    }
+
+    @Test
+    public void RollDice_RollOfSeven_PlayerWithEightCards_DiscardsFour() {
+        p2.addResources(ResourceType.BRICK, 8);
+        DiceRoll sevenDice = mockDiceRoll(3, 4);
+        Turn turn = new Turn(game, p1, sevenDice, bank);
+
+        turn.rollDice();
+
+        assertEquals(4, p2.getTotalResourceCount());
+    }
+
+    @Test
+    public void RollDice_RollOfSeven_PlayerWithNineCards_DiscardsFour() {
+        p2.addResources(ResourceType.BRICK, 5);
+        p2.addResources(ResourceType.LUMBER, 4);
+        DiceRoll sevenDice = mockDiceRoll(3, 4);
+        Turn turn = new Turn(game, p1, sevenDice, bank);
+
+        turn.rollDice();
+
+        assertEquals(5, p2.getTotalResourceCount());
+    }
+
+    @Test
+    public void RollDice_RollOfSeven_PlayerWithSevenCards_NoDiscard() {
+        p2.addResources(ResourceType.BRICK, 7);
+        DiceRoll sevenDice = mockDiceRoll(3, 4);
+        Turn turn = new Turn(game, p1, sevenDice, bank);
+
+        turn.rollDice();
+
+        assertEquals(7, p2.getTotalResourceCount());
+    }
+
+    @Test
+    public void GetRobbingCandidates_OpponentSettlementAdjacentToRobberHex_IncludesOpponent() {
+        Vertex vertex = findVertexAdjacentToHex(board.getRobberHex());
+        vertex.setOwner(p2);
+        Turn turn = new Turn(game, p1, dice, bank);
+
+        assertTrue(turn.getRobbingCandidates().contains(p2));
+    }
+
+    @Test
+    public void GetRobbingCandidates_ActivePlayerSettlementAdjacentToRobberHex_ExcludesActivePlayer() {
+        Vertex vertex = findVertexAdjacentToHex(board.getRobberHex());
+        vertex.setOwner(p1);
+        Turn turn = new Turn(game, p1, dice, bank);
+
+        assertFalse(turn.getRobbingCandidates().contains(p1));
+    }
+
+    @Test
+    public void GetRobbingCandidates_NoSettlementsAdjacentToRobberHex_ReturnsEmptyList() {
+        Turn turn = new Turn(game, p1, dice, bank);
+
+        assertTrue(turn.getRobbingCandidates().isEmpty());
+    }
+
+    @Test
+    public void MoveRobber_BeforeSevenRolled_ThrowsIllegalStateException() {
+        Turn turn = new Turn(game, p1, dice, bank);
+        Hex target = findNonDesertHex();
+
+        assertThrows(IllegalStateException.class, () -> turn.moveRobber(board.getHexes().indexOf(target)));
+    }
+
+    @Test
+    public void MoveRobber_ToCurrentRobberHex_ThrowsIllegalArgumentException() {
+        DiceRoll sevenDice = mockDiceRoll(3, 4);
+        Turn turn = new Turn(game, p1, sevenDice, bank);
+        turn.rollDice();
+        int currentRobberHexId = board.getHexes().indexOf(board.getRobberHex());
+
+        assertThrows(IllegalArgumentException.class, () -> turn.moveRobber(currentRobberHexId));
+    }
+
+    @Test
+    public void MoveRobber_WithInvalidHexId_ThrowsIllegalArgumentException() {
+        DiceRoll sevenDice = mockDiceRoll(3, 4);
+        Turn turn = new Turn(game, p1, sevenDice, bank);
+        turn.rollDice();
+
+        assertThrows(IllegalArgumentException.class, () -> turn.moveRobber(99));
+    }
+
+    @Test
+    public void MoveRobber_ToValidHex_UpdatesBoardRobberHex() {
+        DiceRoll sevenDice = mockDiceRoll(3, 4);
+        Turn turn = new Turn(game, p1, sevenDice, bank);
+        turn.rollDice();
+        Hex target = findNonDesertHex();
+
+        turn.moveRobber(board.getHexes().indexOf(target));
+
+        assertEquals(target, board.getRobberHex());
+    }
+
+    @Test
+    public void MoveRobber_CalledTwice_ThrowsIllegalStateException() {
+        DiceRoll sevenDice = mockDiceRoll(3, 4);
+        Turn turn = new Turn(game, p1, sevenDice, bank);
+        turn.rollDice();
+        Hex firstTarget = findNonDesertHex();
+        turn.moveRobber(board.getHexes().indexOf(firstTarget));
+
+        assertThrows(IllegalStateException.class, () -> turn.moveRobber(99));
+    }
+
+    @Test
+    public void Steal_BeforeMovingRobber_ThrowsIllegalStateException() {
+        DiceRoll sevenDice = mockDiceRoll(3, 4);
+        Turn turn = new Turn(game, p1, sevenDice, bank);
+        turn.rollDice();
+
+        assertThrows(IllegalStateException.class, () -> turn.steal(p2));
+    }
+
+    @Test
+    public void Steal_WhenNoRobbingCandidates_ThrowsIllegalStateException() {
+        Hex target = findNonDesertHex();
+        DiceRoll sevenDice = mockDiceRoll(3, 4);
+        Turn turn = new Turn(game, p1, sevenDice, bank);
+        turn.rollDice();
+        turn.moveRobber(board.getHexes().indexOf(target));
+
+        assertThrows(IllegalStateException.class, () -> turn.steal(p2));
+    }
+
+    @Test
+    public void Steal_FromPlayerNotAdjacentToRobberHex_ThrowsIllegalArgumentException() {
+        Hex target = findNonDesertHex();
+        Vertex vertex = findVertexAdjacentToHex(target);
+        vertex.setOwner(p3);
+
+        DiceRoll sevenDice = mockDiceRoll(3, 4);
+        Turn turn = new Turn(game, p1, sevenDice, bank);
+        turn.rollDice();
+        turn.moveRobber(board.getHexes().indexOf(target));
+
+        assertThrows(IllegalArgumentException.class, () -> turn.steal(p2));
+    }
+
+    @Test
+    public void Steal_TargetHasNoResourceCards_ThrowsIllegalStateException() {
+        Hex target = findNonDesertHex();
+        Vertex vertex = findVertexAdjacentToHex(target);
+        vertex.setOwner(p2);
+
+        DiceRoll sevenDice = mockDiceRoll(3, 4);
+        Turn turn = new Turn(game, p1, sevenDice, bank);
+        turn.rollDice();
+        turn.moveRobber(board.getHexes().indexOf(target));
+
+        assertThrows(IllegalStateException.class, () -> turn.steal(p2));
+    }
+
+    @Test
+    public void Steal_FromValidCandidate_TransfersOneResourceCardToActivePlayer() {
+        Hex target = findNonDesertHex();
+        Vertex vertex = findVertexAdjacentToHex(target);
+        vertex.setOwner(p2);
+        p2.addResources(ResourceType.ORE, 1);
+
+        DiceRoll sevenDice = mockDiceRoll(3, 4);
+        Turn turn = new Turn(game, p1, sevenDice, bank);
+        turn.rollDice();
+        turn.moveRobber(board.getHexes().indexOf(target));
+
+        turn.steal(p2);
+
+        assertAll(
+                () -> assertEquals(0, p2.getResourceCount(ResourceType.ORE)),
+                () -> assertEquals(1, p1.getResourceCount(ResourceType.ORE))
+        );
+    }
+
     @Test
     public void BuildRoad_PlayerDoesNotHaveBrick_ThrowsIllegalStateException() {
         p2.addResources(ResourceType.LUMBER, 1);

--- a/src/test/java/domain/TurnTest.java
+++ b/src/test/java/domain/TurnTest.java
@@ -127,6 +127,18 @@ public class TurnTest {
         throw new IllegalStateException("No vertex found adjacent to a hex with number token " + number);
     }
 
+    private Vertex findVertexAdjacentToExactlyOneHexWithNumber(int number) {
+        for (Vertex vertex : board.getVertices()) {
+            long matches = vertex.getAdjacentHexes().stream()
+                    .filter(hex -> hex.getNumberToken() == number && hex.producesResource())
+                    .count();
+            if (matches == 1) {
+                return vertex;
+            }
+        }
+        throw new IllegalStateException("No vertex found adjacent to exactly one hex with number token " + number);
+    }
+
     @Test
     public void RollDice_ValidCall_ReturnsRollValue() {
         DiceRoll fixedDice = mockDiceRoll(4, 4);
@@ -178,6 +190,23 @@ public class TurnTest {
 
         DiceRoll sevenDice = mockDiceRoll(3, 4);
         Turn turn = new Turn(game, p1, sevenDice, bank);
+
+        turn.rollDice();
+
+        assertEquals(0, p1.getTotalResourceCount());
+    }
+
+    @Test
+    public void RollDice_NumberMatchesRobberHex_DoesNotProduceFromThatHex() {
+        Vertex vertex = findVertexAdjacentToExactlyOneHexWithNumber(8);
+        vertex.setOwner(p1);
+        Hex robbedHex = vertex.getAdjacentHexes().stream()
+                .filter(hex -> hex.getNumberToken() == 8 && hex.producesResource())
+                .findFirst().get();
+        board.setRobberHex(robbedHex);
+
+        DiceRoll fixedDice = mockDiceRoll(4, 4);
+        Turn turn = new Turn(game, p1, fixedDice, new Bank());
 
         turn.rollDice();
 
@@ -373,7 +402,7 @@ public class TurnTest {
     }
 
     @Test
-    public void Steal_TargetHasNoResourceCards_ThrowsIllegalStateException() {
+    public void Steal_TargetHasNoResourceCards_CompletesWithNoTransferAndResolvesRobber() {
         Hex target = findNonDesertHex();
         Vertex vertex = findVertexAdjacentToHex(target);
         vertex.setOwner(p2);
@@ -383,7 +412,13 @@ public class TurnTest {
         turn.rollDice();
         turn.moveRobber(board.getHexes().indexOf(target));
 
-        assertThrows(IllegalStateException.class, () -> turn.steal(p2));
+        turn.steal(p2);
+
+        assertAll(
+                () -> assertEquals(0, p2.getTotalResourceCount()),
+                () -> assertEquals(0, p1.getTotalResourceCount()),
+                () -> assertDoesNotThrow(turn::advanceToBuild)
+        );
     }
 
     @Test
@@ -488,6 +523,25 @@ public class TurnTest {
         turn.advanceToBuild();
 
         assertEquals(TurnPhase.BUILD, turn.getPhase());
+    }
+
+    @Test
+    public void AdvanceToBuild_WithPendingTrade_RejectsAndClearsTheOffer() {
+        p1.addResources(ResourceType.BRICK, 1);
+        DiceRoll fixedDice = mockDiceRoll(4, 4);
+        Turn turn = new Turn(game, p1, fixedDice, bank);
+        turn.rollDice();
+
+        Map<ResourceType, Integer> offering = Map.of(ResourceType.BRICK, 1);
+        Map<ResourceType, Integer> requesting = Map.of(ResourceType.WOOL, 1);
+        TradeOffer offer = turn.proposeTrade(p2, offering, requesting);
+
+        turn.advanceToBuild();
+
+        assertAll(
+                () -> assertEquals(TradeOffer.TradeStatus.REJECTED, offer.getStatus()),
+                () -> assertEquals(Optional.empty(), turn.getPendingTrade())
+        );
     }
 
     @Test
@@ -1173,6 +1227,19 @@ public class TurnTest {
     }
 
     @Test
+    public void ProposeTrade_RecipientNotInGame_ThrowsIllegalArgumentException() {
+        Player outsider = new Player("outsider", PlayerColor.RED);
+        DiceRoll fixedDice = mockDiceRoll(4, 4);
+        Turn turn = new Turn(game, p1, fixedDice, bank);
+        turn.rollDice();
+
+        Map<ResourceType, Integer> offering = Map.of(ResourceType.BRICK, 1);
+        Map<ResourceType, Integer> requesting = Map.of(ResourceType.WOOL, 1);
+
+        assertThrows(IllegalArgumentException.class, () -> turn.proposeTrade(outsider, offering, requesting));
+    }
+
+    @Test
     public void ProposeTrade_WhenTradeAlreadyPending_ThrowsIllegalStateException() {
         p1.addResources(ResourceType.BRICK, 1);
         DiceRoll fixedDice = mockDiceRoll(4, 4);
@@ -1408,6 +1475,15 @@ public class TurnTest {
         player.addResources(ResourceType.GRAIN, 1);
     }
 
+    private void cycleDevelopmentCardCostThroughBank(Player player, Bank bank) {
+        bank.deduct(ResourceType.ORE, 1);
+        player.addResources(ResourceType.ORE, 1);
+        bank.deduct(ResourceType.WOOL, 1);
+        player.addResources(ResourceType.WOOL, 1);
+        bank.deduct(ResourceType.GRAIN, 1);
+        player.addResources(ResourceType.GRAIN, 1);
+    }
+
     private DevelopmentCard buyUntilNonVictoryPointCard(Turn turn, Player player) {
         DevelopmentCard card;
         do {
@@ -1439,10 +1515,13 @@ public class TurnTest {
 
     @Test
     public void BuyDevelopmentCard_NoCardsRemainInDeck_ThrowsIllegalStateException() {
-        Turn turn = newTurnInBuildPhase(p1);
+        Bank freshBank = new Bank();
+        Turn turn = new Turn(game, p1, mockDiceRoll(4, 4), freshBank);
+        turn.rollDice();
+        turn.advanceToBuild();
         int deckSize = turn.getRemainingDeckSize();
         for (int i = 0; i < deckSize; i++) {
-            giveDevelopmentCardCost(p1);
+            cycleDevelopmentCardCostThroughBank(p1, freshBank);
             turn.buyDevelopmentCard();
         }
 
@@ -1452,15 +1531,18 @@ public class TurnTest {
 
     @Test
     public void BuyDevelopmentCard_PlayerHasExactCostAndOneCardRemains_DeductsCostAndAddsCardToHand() {
-        Turn turn = newTurnInBuildPhase(p1);
+        Bank freshBank = new Bank();
+        Turn turn = new Turn(game, p1, mockDiceRoll(4, 4), freshBank);
+        turn.rollDice();
+        turn.advanceToBuild();
         int deckSize = turn.getRemainingDeckSize();
         for (int i = 0; i < deckSize - 1; i++) {
-            giveDevelopmentCardCost(p1);
+            cycleDevelopmentCardCostThroughBank(p1, freshBank);
             turn.buyDevelopmentCard();
         }
         assertEquals(1, turn.getRemainingDeckSize());
         int handSizeBefore = turn.getPlayerHand(p1).size();
-        giveDevelopmentCardCost(p1);
+        cycleDevelopmentCardCostThroughBank(p1, freshBank);
 
         turn.buyDevelopmentCard();
 
@@ -1488,6 +1570,8 @@ public class TurnTest {
         turn.rollDice();
         DevelopmentCard first = new DevelopmentCard(DevelopmentCardType.KNIGHT);
         DevelopmentCard second = new DevelopmentCard(DevelopmentCardType.KNIGHT);
+        game.addDevelopmentCardToHand(p1, first);
+        game.addDevelopmentCardToHand(p1, second);
         turn.playDevelopmentCard(p1, first);
 
         assertThrows(IllegalStateException.class, () -> turn.playDevelopmentCard(p1, second));
@@ -1508,6 +1592,18 @@ public class TurnTest {
         turn.rollDice();
         DevelopmentCard card = new DevelopmentCard(DevelopmentCardType.KNIGHT);
         card.markAsPlayed();
+        game.addDevelopmentCardToHand(p1, card);
+
+        assertThrows(IllegalStateException.class, () -> turn.playDevelopmentCard(p1, card));
+    }
+
+    @Test
+    public void PlayDevelopmentCard_VictoryPointCard_ThrowsIllegalStateException() {
+        DiceRoll fixedDice = mockDiceRoll(4, 4);
+        Turn turn = new Turn(game, p1, fixedDice, bank);
+        turn.rollDice();
+        DevelopmentCard card = new DevelopmentCard(DevelopmentCardType.VICTORY_POINT);
+        game.addDevelopmentCardToHand(p1, card);
 
         assertThrows(IllegalStateException.class, () -> turn.playDevelopmentCard(p1, card));
     }
@@ -1518,6 +1614,7 @@ public class TurnTest {
         Turn turn = new Turn(game, p1, fixedDice, bank);
         turn.rollDice();
         DevelopmentCard card = new DevelopmentCard(DevelopmentCardType.KNIGHT);
+        game.addDevelopmentCardToHand(p1, card);
 
         turn.playDevelopmentCard(p1, card);
 

--- a/src/test/java/domain/TurnTest.java
+++ b/src/test/java/domain/TurnTest.java
@@ -1401,6 +1401,171 @@ public class TurnTest {
                 () -> assertEquals(0, bank.getResourceCount(ResourceType.WOOL))
         );
     }
+
+    private void giveDevelopmentCardCost(Player player) {
+        player.addResources(ResourceType.ORE, 1);
+        player.addResources(ResourceType.WOOL, 1);
+        player.addResources(ResourceType.GRAIN, 1);
+    }
+
+    private DevelopmentCard buyUntilNonVictoryPointCard(Turn turn, Player player) {
+        DevelopmentCard card;
+        do {
+            giveDevelopmentCardCost(player);
+            turn.buyDevelopmentCard();
+            List<DevelopmentCard> hand = turn.getPlayerHand(player);
+            card = hand.get(hand.size() - 1);
+        } while (card.getType() == DevelopmentCardType.VICTORY_POINT);
+        return card;
+    }
+
+    @Test
+    public void BuyDevelopmentCard_OutsideBuildPhase_ThrowsIllegalStateException() {
+        DiceRoll fixedDice = mockDiceRoll(4, 4);
+        Turn turn = new Turn(game, p1, fixedDice, bank);
+        turn.rollDice();
+
+        assertThrows(IllegalStateException.class, turn::buyDevelopmentCard);
+    }
+
+    @Test
+    public void BuyDevelopmentCard_PlayerCannotAffordCost_ThrowsIllegalStateException() {
+        p1.addResources(ResourceType.WOOL, 1);
+        p1.addResources(ResourceType.GRAIN, 1);
+        Turn turn = newTurnInBuildPhase(p1);
+
+        assertThrows(IllegalStateException.class, turn::buyDevelopmentCard);
+    }
+
+    @Test
+    public void BuyDevelopmentCard_NoCardsRemainInDeck_ThrowsIllegalStateException() {
+        Turn turn = newTurnInBuildPhase(p1);
+        int deckSize = turn.getRemainingDeckSize();
+        for (int i = 0; i < deckSize; i++) {
+            giveDevelopmentCardCost(p1);
+            turn.buyDevelopmentCard();
+        }
+
+        assertEquals(0, turn.getRemainingDeckSize());
+        assertThrows(IllegalStateException.class, turn::buyDevelopmentCard);
+    }
+
+    @Test
+    public void BuyDevelopmentCard_PlayerHasExactCostAndOneCardRemains_DeductsCostAndAddsCardToHand() {
+        Turn turn = newTurnInBuildPhase(p1);
+        int deckSize = turn.getRemainingDeckSize();
+        for (int i = 0; i < deckSize - 1; i++) {
+            giveDevelopmentCardCost(p1);
+            turn.buyDevelopmentCard();
+        }
+        assertEquals(1, turn.getRemainingDeckSize());
+        int handSizeBefore = turn.getPlayerHand(p1).size();
+        giveDevelopmentCardCost(p1);
+
+        turn.buyDevelopmentCard();
+
+        assertAll(
+                () -> assertEquals(0, p1.getResourceCount(ResourceType.ORE)),
+                () -> assertEquals(0, p1.getResourceCount(ResourceType.WOOL)),
+                () -> assertEquals(0, p1.getResourceCount(ResourceType.GRAIN)),
+                () -> assertEquals(0, turn.getRemainingDeckSize()),
+                () -> assertEquals(handSizeBefore + 1, turn.getPlayerHand(p1).size())
+        );
+    }
+
+    @Test
+    public void PlayDevelopmentCard_OutsideTradeOrBuildPhase_ThrowsIllegalStateException() {
+        Turn turn = new Turn(game, p1, dice, bank);
+        DevelopmentCard card = new DevelopmentCard(DevelopmentCardType.KNIGHT);
+
+        assertThrows(IllegalStateException.class, () -> turn.playDevelopmentCard(p1, card));
+    }
+
+    @Test
+    public void PlayDevelopmentCard_DevCardAlreadyPlayedThisTurn_ThrowsIllegalStateException() {
+        DiceRoll fixedDice = mockDiceRoll(4, 4);
+        Turn turn = new Turn(game, p1, fixedDice, bank);
+        turn.rollDice();
+        DevelopmentCard first = new DevelopmentCard(DevelopmentCardType.KNIGHT);
+        DevelopmentCard second = new DevelopmentCard(DevelopmentCardType.KNIGHT);
+        turn.playDevelopmentCard(p1, first);
+
+        assertThrows(IllegalStateException.class, () -> turn.playDevelopmentCard(p1, second));
+    }
+
+    @Test
+    public void PlayDevelopmentCard_NonVictoryPointCardPurchasedThisTurn_ThrowsIllegalStateException() {
+        Turn turn = newTurnInBuildPhase(p1);
+        DevelopmentCard purchased = buyUntilNonVictoryPointCard(turn, p1);
+
+        assertThrows(IllegalStateException.class, () -> turn.playDevelopmentCard(p1, purchased));
+    }
+
+    @Test
+    public void PlayDevelopmentCard_CardAlreadyPlayed_ThrowsIllegalStateException() {
+        DiceRoll fixedDice = mockDiceRoll(4, 4);
+        Turn turn = new Turn(game, p1, fixedDice, bank);
+        turn.rollDice();
+        DevelopmentCard card = new DevelopmentCard(DevelopmentCardType.KNIGHT);
+        card.markAsPlayed();
+
+        assertThrows(IllegalStateException.class, () -> turn.playDevelopmentCard(p1, card));
+    }
+
+    @Test
+    public void PlayDevelopmentCard_UnplayedCardFromPriorTurn_MarksCardAsPlayed() {
+        DiceRoll fixedDice = mockDiceRoll(4, 4);
+        Turn turn = new Turn(game, p1, fixedDice, bank);
+        turn.rollDice();
+        DevelopmentCard card = new DevelopmentCard(DevelopmentCardType.KNIGHT);
+
+        turn.playDevelopmentCard(p1, card);
+
+        assertTrue(card.isPlayed());
+    }
+
+    @Test
+    public void GetPlayerHand_PlayerWithNoCards_ReturnsEmptyList() {
+        Turn turn = new Turn(game, p1, dice, bank);
+
+        assertTrue(turn.getPlayerHand(p1).isEmpty());
+    }
+
+    @Test
+    public void GetPlayerHand_AfterBuyingOneCard_ReturnsListContainingPurchasedCard() {
+        giveDevelopmentCardCost(p1);
+        Turn turn = newTurnInBuildPhase(p1);
+
+        turn.buyDevelopmentCard();
+
+        assertEquals(1, turn.getPlayerHand(p1).size());
+    }
+
+    @Test
+    public void GetPlayerHand_ReturnedList_IsUnmodifiable() {
+        Turn turn = new Turn(game, p1, dice, bank);
+        List<DevelopmentCard> hand = turn.getPlayerHand(p1);
+
+        assertThrows(UnsupportedOperationException.class,
+                () -> hand.add(new DevelopmentCard(DevelopmentCardType.KNIGHT)));
+    }
+
+    @Test
+    public void GetRemainingDeckSize_NewTurn_Returns25() {
+        Turn turn = new Turn(game, p1, dice, bank);
+
+        assertEquals(25, turn.getRemainingDeckSize());
+    }
+
+    @Test
+    public void GetRemainingDeckSize_AfterBuyingOneCard_DecreasesByOne() {
+        giveDevelopmentCardCost(p1);
+        Turn turn = newTurnInBuildPhase(p1);
+
+        turn.buyDevelopmentCard();
+
+        assertEquals(24, turn.getRemainingDeckSize());
+    }
 }
 
 

--- a/src/test/java/domain/TurnTest.java
+++ b/src/test/java/domain/TurnTest.java
@@ -1161,6 +1161,206 @@ public class TurnTest {
         assertEquals(p3, game.getBoard().getVertex(vertexId).getOwner().orElse(null));
         assertTrue(game.getBoard().getVertex(vertexId).isCity());
     }
+
+    @Test
+    public void ProposeTrade_OutsideTradePhase_ThrowsIllegalStateException() {
+        Turn turn = new Turn(game, p1, dice, bank);
+
+        Map<ResourceType, Integer> offering = Map.of(ResourceType.BRICK, 1);
+        Map<ResourceType, Integer> requesting = Map.of(ResourceType.WOOL, 1);
+
+        assertThrows(IllegalStateException.class, () -> turn.proposeTrade(p2, offering, requesting));
+    }
+
+    @Test
+    public void ProposeTrade_WhenTradeAlreadyPending_ThrowsIllegalStateException() {
+        p1.addResources(ResourceType.BRICK, 1);
+        DiceRoll fixedDice = mockDiceRoll(4, 4);
+        Turn turn = new Turn(game, p1, fixedDice, bank);
+        turn.rollDice();
+
+        Map<ResourceType, Integer> offering = Map.of(ResourceType.BRICK, 1);
+        Map<ResourceType, Integer> requesting = Map.of(ResourceType.WOOL, 1);
+        turn.proposeTrade(p2, offering, requesting);
+
+        assertThrows(IllegalStateException.class, () -> turn.proposeTrade(p3, offering, requesting));
+    }
+
+    @Test
+    public void ProposeTrade_OffererCannotAffordOffering_ThrowsIllegalArgumentException() {
+        DiceRoll fixedDice = mockDiceRoll(4, 4);
+        Turn turn = new Turn(game, p1, fixedDice, bank);
+        turn.rollDice();
+
+        Map<ResourceType, Integer> offering = Map.of(ResourceType.BRICK, 1);
+        Map<ResourceType, Integer> requesting = Map.of(ResourceType.WOOL, 1);
+
+        assertThrows(IllegalArgumentException.class, () -> turn.proposeTrade(p2, offering, requesting));
+    }
+
+    @Test
+    public void ProposeTrade_OffererHasExactlyOfferedAmount_CreatesAndStoresPendingTrade() {
+        p1.addResources(ResourceType.BRICK, 1);
+        DiceRoll fixedDice = mockDiceRoll(4, 4);
+        Turn turn = new Turn(game, p1, fixedDice, bank);
+        turn.rollDice();
+
+        Map<ResourceType, Integer> offering = Map.of(ResourceType.BRICK, 1);
+        Map<ResourceType, Integer> requesting = Map.of(ResourceType.WOOL, 1);
+
+        TradeOffer offer = turn.proposeTrade(p2, offering, requesting);
+
+        assertAll(
+                () -> assertTrue(offer.isPending()),
+                () -> assertEquals(Optional.of(offer), turn.getPendingTrade())
+        );
+    }
+
+    @Test
+    public void ProposeTrade_AfterPriorOfferResolved_CreatesNewPendingTrade() {
+        p1.addResources(ResourceType.BRICK, 1);
+        p1.addResources(ResourceType.LUMBER, 1);
+        DiceRoll fixedDice = mockDiceRoll(4, 4);
+        Turn turn = new Turn(game, p1, fixedDice, bank);
+        turn.rollDice();
+
+        Map<ResourceType, Integer> offering1 = Map.of(ResourceType.BRICK, 1);
+        Map<ResourceType, Integer> requesting1 = Map.of(ResourceType.WOOL, 1);
+        TradeOffer first = turn.proposeTrade(p2, offering1, requesting1);
+        turn.rejectTrade(first);
+
+        Map<ResourceType, Integer> offering2 = Map.of(ResourceType.LUMBER, 1);
+        Map<ResourceType, Integer> requesting2 = Map.of(ResourceType.ORE, 1);
+        TradeOffer second = turn.proposeTrade(p3, offering2, requesting2);
+
+        assertAll(
+                () -> assertTrue(second.isPending()),
+                () -> assertEquals(Optional.of(second), turn.getPendingTrade())
+        );
+    }
+
+    @Test
+    public void AcceptTrade_NoMatchingPendingTrade_ThrowsIllegalStateException() {
+        p1.addResources(ResourceType.BRICK, 1);
+        DiceRoll fixedDice = mockDiceRoll(4, 4);
+        Turn turn = new Turn(game, p1, fixedDice, bank);
+        turn.rollDice();
+
+        Map<ResourceType, Integer> offering = Map.of(ResourceType.BRICK, 1);
+        Map<ResourceType, Integer> requesting = Map.of(ResourceType.WOOL, 1);
+        TradeOffer foreignOffer = new TradeOffer(p1, p2, offering, requesting);
+
+        assertThrows(IllegalStateException.class, () -> turn.acceptTrade(foreignOffer));
+    }
+
+    @Test
+    public void AcceptTrade_OffererCannotAffordOffering_ThrowsIllegalStateException() {
+        p1.addResources(ResourceType.BRICK, 1);
+        p2.addResources(ResourceType.WOOL, 1);
+        DiceRoll fixedDice = mockDiceRoll(4, 4);
+        Turn turn = new Turn(game, p1, fixedDice, bank);
+        turn.rollDice();
+
+        Map<ResourceType, Integer> offering = Map.of(ResourceType.BRICK, 1);
+        Map<ResourceType, Integer> requesting = Map.of(ResourceType.WOOL, 1);
+        TradeOffer offer = turn.proposeTrade(p2, offering, requesting);
+
+        p1.removeResources(ResourceType.BRICK, 1);
+
+        assertThrows(IllegalStateException.class, () -> turn.acceptTrade(offer));
+    }
+
+    @Test
+    public void AcceptTrade_RecipientCannotAffordRequesting_ThrowsIllegalStateException() {
+        p1.addResources(ResourceType.BRICK, 1);
+        DiceRoll fixedDice = mockDiceRoll(4, 4);
+        Turn turn = new Turn(game, p1, fixedDice, bank);
+        turn.rollDice();
+
+        Map<ResourceType, Integer> offering = Map.of(ResourceType.BRICK, 1);
+        Map<ResourceType, Integer> requesting = Map.of(ResourceType.WOOL, 1);
+        TradeOffer offer = turn.proposeTrade(p2, offering, requesting);
+
+        assertThrows(IllegalStateException.class, () -> turn.acceptTrade(offer));
+    }
+
+    @Test
+    public void AcceptTrade_BothPlayersCanAfford_ExchangesResourcesAndClearsPendingTrade() {
+        p1.addResources(ResourceType.BRICK, 1);
+        p2.addResources(ResourceType.WOOL, 1);
+        DiceRoll fixedDice = mockDiceRoll(4, 4);
+        Turn turn = new Turn(game, p1, fixedDice, bank);
+        turn.rollDice();
+
+        Map<ResourceType, Integer> offering = Map.of(ResourceType.BRICK, 1);
+        Map<ResourceType, Integer> requesting = Map.of(ResourceType.WOOL, 1);
+        TradeOffer offer = turn.proposeTrade(p2, offering, requesting);
+
+        turn.acceptTrade(offer);
+
+        assertAll(
+                () -> assertEquals(0, p1.getResourceCount(ResourceType.BRICK)),
+                () -> assertEquals(1, p1.getResourceCount(ResourceType.WOOL)),
+                () -> assertEquals(1, p2.getResourceCount(ResourceType.BRICK)),
+                () -> assertEquals(0, p2.getResourceCount(ResourceType.WOOL)),
+                () -> assertEquals(TradeOffer.TradeStatus.ACCEPTED, offer.getStatus()),
+                () -> assertEquals(Optional.empty(), turn.getPendingTrade())
+        );
+    }
+
+    @Test
+    public void RejectTrade_NoMatchingPendingTrade_ThrowsIllegalStateException() {
+        p1.addResources(ResourceType.BRICK, 1);
+        DiceRoll fixedDice = mockDiceRoll(4, 4);
+        Turn turn = new Turn(game, p1, fixedDice, bank);
+        turn.rollDice();
+
+        Map<ResourceType, Integer> offering = Map.of(ResourceType.BRICK, 1);
+        Map<ResourceType, Integer> requesting = Map.of(ResourceType.WOOL, 1);
+        TradeOffer foreignOffer = new TradeOffer(p1, p2, offering, requesting);
+
+        assertThrows(IllegalStateException.class, () -> turn.rejectTrade(foreignOffer));
+    }
+
+    @Test
+    public void RejectTrade_PendingOffer_MarksRejectedAndClearsPendingTrade() {
+        p1.addResources(ResourceType.BRICK, 1);
+        DiceRoll fixedDice = mockDiceRoll(4, 4);
+        Turn turn = new Turn(game, p1, fixedDice, bank);
+        turn.rollDice();
+
+        Map<ResourceType, Integer> offering = Map.of(ResourceType.BRICK, 1);
+        Map<ResourceType, Integer> requesting = Map.of(ResourceType.WOOL, 1);
+        TradeOffer offer = turn.proposeTrade(p2, offering, requesting);
+
+        turn.rejectTrade(offer);
+
+        assertAll(
+                () -> assertEquals(TradeOffer.TradeStatus.REJECTED, offer.getStatus()),
+                () -> assertEquals(Optional.empty(), turn.getPendingTrade())
+        );
+    }
+
+    @Test
+    public void GetPendingTrade_NoOfferProposed_ReturnsEmpty() {
+        Turn turn = new Turn(game, p1, dice, bank);
+
+        assertEquals(Optional.empty(), turn.getPendingTrade());
+    }
+
+    @Test
+    public void GetPendingTrade_AfterProposeTrade_ReturnsTheOffer() {
+        p1.addResources(ResourceType.BRICK, 1);
+        DiceRoll fixedDice = mockDiceRoll(4, 4);
+        Turn turn = new Turn(game, p1, fixedDice, bank);
+        turn.rollDice();
+
+        Map<ResourceType, Integer> offering = Map.of(ResourceType.BRICK, 1);
+        Map<ResourceType, Integer> requesting = Map.of(ResourceType.WOOL, 1);
+        TradeOffer offer = turn.proposeTrade(p2, offering, requesting);
+
+        assertEquals(Optional.of(offer), turn.getPendingTrade());
+    }
 }
 
 

--- a/src/test/java/domain/TurnTest.java
+++ b/src/test/java/domain/TurnTest.java
@@ -400,6 +400,129 @@ public class TurnTest {
     }
 
     @Test
+    public void AdvanceToBuild_FromTradePhase_SetsPhaseToBuild() {
+        DiceRoll fixedDice = mockDiceRoll(4, 4);
+        Turn turn = new Turn(game, p1, fixedDice, bank);
+        turn.rollDice();
+
+        turn.advanceToBuild();
+
+        assertEquals(TurnPhase.BUILD, turn.getPhase());
+    }
+
+    @Test
+    public void AdvanceToBuild_FromProductionPhase_ThrowsIllegalStateException() {
+        Turn turn = new Turn(game, p1, dice, bank);
+
+        assertThrows(IllegalStateException.class, turn::advanceToBuild);
+    }
+
+    @Test
+    public void AdvanceToBuild_FromBuildPhase_ThrowsIllegalStateException() {
+        DiceRoll fixedDice = mockDiceRoll(4, 4);
+        Turn turn = new Turn(game, p1, fixedDice, bank);
+        turn.rollDice();
+        turn.advanceToBuild();
+
+        assertThrows(IllegalStateException.class, turn::advanceToBuild);
+    }
+
+    @Test
+    public void AdvanceToBuild_WithRobberMovePending_ThrowsIllegalStateException() {
+        DiceRoll sevenDice = mockDiceRoll(3, 4);
+        Turn turn = new Turn(game, p1, sevenDice, bank);
+        turn.rollDice();
+
+        assertThrows(IllegalStateException.class, turn::advanceToBuild);
+    }
+
+    @Test
+    public void AdvanceToBuild_WithStealPending_ThrowsIllegalStateException() {
+        Hex target = findNonDesertHex();
+        Vertex vertex = findVertexAdjacentToHex(target);
+        vertex.setOwner(p2);
+        p2.addResources(ResourceType.ORE, 1);
+
+        DiceRoll sevenDice = mockDiceRoll(3, 4);
+        Turn turn = new Turn(game, p1, sevenDice, bank);
+        turn.rollDice();
+        turn.moveRobber(board.getHexes().indexOf(target));
+
+        assertThrows(IllegalStateException.class, turn::advanceToBuild);
+    }
+
+    @Test
+    public void AdvanceToBuild_AfterRobberFullyResolved_SetsPhaseToBuild() {
+        Hex target = findNonDesertHex();
+        Vertex vertex = findVertexAdjacentToHex(target);
+        vertex.setOwner(p2);
+        p2.addResources(ResourceType.ORE, 1);
+
+        DiceRoll sevenDice = mockDiceRoll(3, 4);
+        Turn turn = new Turn(game, p1, sevenDice, bank);
+        turn.rollDice();
+        turn.moveRobber(board.getHexes().indexOf(target));
+        turn.steal(p2);
+
+        turn.advanceToBuild();
+
+        assertEquals(TurnPhase.BUILD, turn.getPhase());
+    }
+
+    @Test
+    public void AdvanceToBuild_AfterRobberMovedWithNoCandidates_SetsPhaseToBuild() {
+        Hex target = findNonDesertHex();
+
+        DiceRoll sevenDice = mockDiceRoll(3, 4);
+        Turn turn = new Turn(game, p1, sevenDice, bank);
+        turn.rollDice();
+        turn.moveRobber(board.getHexes().indexOf(target));
+
+        turn.advanceToBuild();
+
+        assertEquals(TurnPhase.BUILD, turn.getPhase());
+    }
+
+    @Test
+    public void EndTurn_FromBuildPhase_SetsPhaseToDone() {
+        DiceRoll fixedDice = mockDiceRoll(4, 4);
+        Turn turn = new Turn(game, p1, fixedDice, bank);
+        turn.rollDice();
+        turn.advanceToBuild();
+
+        turn.endTurn();
+
+        assertEquals(TurnPhase.DONE, turn.getPhase());
+    }
+
+    @Test
+    public void EndTurn_FromTradePhase_ThrowsIllegalStateException() {
+        DiceRoll fixedDice = mockDiceRoll(4, 4);
+        Turn turn = new Turn(game, p1, fixedDice, bank);
+        turn.rollDice();
+
+        assertThrows(IllegalStateException.class, turn::endTurn);
+    }
+
+    @Test
+    public void EndTurn_FromProductionPhase_ThrowsIllegalStateException() {
+        Turn turn = new Turn(game, p1, dice, bank);
+
+        assertThrows(IllegalStateException.class, turn::endTurn);
+    }
+
+    @Test
+    public void EndTurn_CalledTwice_ThrowsIllegalStateException() {
+        DiceRoll fixedDice = mockDiceRoll(4, 4);
+        Turn turn = new Turn(game, p1, fixedDice, bank);
+        turn.rollDice();
+        turn.advanceToBuild();
+        turn.endTurn();
+
+        assertThrows(IllegalStateException.class, turn::endTurn);
+    }
+
+    @Test
     public void BuildRoad_PlayerDoesNotHaveBrick_ThrowsIllegalStateException() {
         p2.addResources(ResourceType.LUMBER, 1);
         Turn turn = new Turn(game, p2, dice, bank);

--- a/src/test/java/domain/TurnTest.java
+++ b/src/test/java/domain/TurnTest.java
@@ -157,7 +157,7 @@ public class TurnTest {
                 .findFirst().get().getTerrainType().getResourceType();
 
         DiceRoll fixedDice = mockDiceRoll(4, 4);
-        Turn turn = new Turn(game, p1, fixedDice, bank);
+        Turn turn = new Turn(game, p1, fixedDice, new Bank());
 
         turn.rollDice();
 

--- a/src/test/java/domain/TurnTest.java
+++ b/src/test/java/domain/TurnTest.java
@@ -109,6 +109,13 @@ public class TurnTest {
         return new DiceRoll(mockRandom);
     }
 
+    private Turn newTurnInBuildPhase(Player player) {
+        Turn turn = new Turn(game, player, mockDiceRoll(4, 4), bank);
+        turn.rollDice();
+        turn.advanceToBuild();
+        return turn;
+    }
+
     private Vertex findVertexAdjacentToNumber(int number) {
         for (Vertex vertex : board.getVertices()) {
             for (Hex hex : vertex.getAdjacentHexes()) {
@@ -537,7 +544,7 @@ public class TurnTest {
     @Test
     public void BuildRoad_PlayerDoesNotHaveBrick_ThrowsIllegalStateException() {
         p2.addResources(ResourceType.LUMBER, 1);
-        Turn turn = new Turn(game, p2, dice, bank);
+        Turn turn = newTurnInBuildPhase(p2);
 
         int edgeId = 2;
         game.getBoard().getEdge(edgeId).getEndpoints().get(0).setOwner(p2);
@@ -550,7 +557,7 @@ public class TurnTest {
     @Test
     public void BuildRoad_PlayerDoesNotHaveLumber_ThrowsIllegalStateException() {
         p2.addResources(ResourceType.BRICK, 1);
-        Turn turn = new Turn(game, p2, dice, bank);
+        Turn turn = newTurnInBuildPhase(p2);
 
         int edgeId = 2;
         game.getBoard().getEdge(edgeId).getEndpoints().get(0).setOwner(p2);
@@ -564,7 +571,7 @@ public class TurnTest {
     public void BuildRoad_PlayerHasExactlyOneBrickAndLumber_NoExceptionThrown() {
         p3.addResources(ResourceType.BRICK, 1);
         p3.addResources(ResourceType.LUMBER, 1);
-        Turn turn = new Turn(game, p3, dice, bank);
+        Turn turn = newTurnInBuildPhase(p3);
 
         int edgeId = 2;
         game.getBoard().getEdge(edgeId).getEndpoints().get(0).setOwner(p3);
@@ -581,7 +588,7 @@ public class TurnTest {
     public void BuildRoad_EdgeIsOccupied_ThrowsIllegalStateException() {
         p3.addResources(ResourceType.BRICK, 1);
         p3.addResources(ResourceType.LUMBER, 1);
-        Turn turn = new Turn(game, p3, dice, bank);
+        Turn turn = newTurnInBuildPhase(p3);
         int edgeId = 4;
         game.getBoard().getEdge(edgeId).getEndpoints().get(0).setOwner(p3);
         board.getEdge(edgeId).setOwner(p4);
@@ -594,7 +601,7 @@ public class TurnTest {
     public void BuildRoad_PlayerHasFourteenRoads_NoExceptionThrown() {
         p3.addResources(ResourceType.BRICK, 1);
         p3.addResources(ResourceType.LUMBER, 1);
-        Turn turn = new Turn(game, p3, dice, bank);
+        Turn turn = newTurnInBuildPhase(p3);
         int edgeId = 15;
         game.getBoard().getEdge(edgeId).getEndpoints().get(0).setOwner(p3);
 
@@ -610,7 +617,7 @@ public class TurnTest {
     public void BuildRoad_PlayerHasFifteenRoads_ThrowsIllegalStateException() {
         p3.addResources(ResourceType.BRICK, 1);
         p3.addResources(ResourceType.LUMBER, 1);
-        Turn turn = new Turn(game, p3, dice, bank);
+        Turn turn = newTurnInBuildPhase(p3);
 
         for (int i = 1; i < 16; i++) {
             board.getEdge(i).setOwner(p3);
@@ -628,7 +635,7 @@ public class TurnTest {
     public void BuildRoad_EdgeIsNotConnectedToExistingNetwork_ThrowsIllegalStateException() {
         p3.addResources(ResourceType.BRICK, 1);
         p3.addResources(ResourceType.LUMBER, 1);
-        Turn turn = new Turn(game, p3, dice, bank);
+        Turn turn = newTurnInBuildPhase(p3);
 
         int edgeId = 17;
 
@@ -641,7 +648,7 @@ public class TurnTest {
     public void BuildRoad_RoadIsConnectedToRoad_NoExceptionThrown() {
         p3.addResources(ResourceType.BRICK, 1);
         p3.addResources(ResourceType.LUMBER, 1);
-        Turn turn = new Turn(game, p3, dice, bank);
+        Turn turn = newTurnInBuildPhase(p3);
 
         int edgeId1 = 11;
         int edgeId2 = 12;
@@ -659,7 +666,7 @@ public class TurnTest {
     public void BuildRoad_RoadIsConnectedToSettlement_NoExceptionThrown() {
         p3.addResources(ResourceType.BRICK, 1);
         p3.addResources(ResourceType.LUMBER, 1);
-        Turn turn = new Turn(game, p3, dice, bank);
+        Turn turn = newTurnInBuildPhase(p3);
 
         int edgeId1 = 11;
         int edgeId2 = 12;
@@ -677,7 +684,7 @@ public class TurnTest {
     public void BuildRoad_RoadIsConnectedToCity_NoExceptionThrown() {
         p3.addResources(ResourceType.BRICK, 1);
         p3.addResources(ResourceType.LUMBER, 1);
-        Turn turn = new Turn(game, p3, dice, bank);
+        Turn turn = newTurnInBuildPhase(p3);
 
         int edgeId1 = 3;
         int edgeId2 = 4;
@@ -696,7 +703,7 @@ public class TurnTest {
     public void BuildRoad_ConnectedToRoadButBlockedByEnemySettlement_ThrowsIllegalStateException() {
         p3.addResources(ResourceType.BRICK, 1);
         p3.addResources(ResourceType.LUMBER, 1);
-        Turn turn = new Turn(game, p3, dice, bank);
+        Turn turn = newTurnInBuildPhase(p3);
 
         int edgeId1 = 11;
         int edgeId2 = 12;
@@ -729,7 +736,7 @@ public class TurnTest {
         p2.addResources(ResourceType.LUMBER, 1);
         p2.addResources(ResourceType.WOOL, 1);
         p2.addResources(ResourceType.GRAIN, 1);
-        Turn turn = new Turn(game, p2, dice, bank);
+        Turn turn = newTurnInBuildPhase(p2);
 
         int vertexId = 2;
         int edgeId = 4;
@@ -745,7 +752,7 @@ public class TurnTest {
         p2.addResources(ResourceType.BRICK, 1);
         p2.addResources(ResourceType.WOOL, 1);
         p2.addResources(ResourceType.GRAIN, 1);
-        Turn turn = new Turn(game, p2, dice, bank);
+        Turn turn = newTurnInBuildPhase(p2);
 
         int vertexId = 2;
         int edgeId = 4;
@@ -761,7 +768,7 @@ public class TurnTest {
         p2.addResources(ResourceType.BRICK, 1);
         p2.addResources(ResourceType.LUMBER, 1);
         p2.addResources(ResourceType.GRAIN, 1);
-        Turn turn = new Turn(game, p2, dice, bank);
+        Turn turn = newTurnInBuildPhase(p2);
 
         int vertexId = 2;
         int edgeId = 4;
@@ -777,7 +784,7 @@ public class TurnTest {
         p2.addResources(ResourceType.BRICK, 1);
         p2.addResources(ResourceType.LUMBER, 1);
         p2.addResources(ResourceType.WOOL, 1);
-        Turn turn = new Turn(game, p2, dice, bank);
+        Turn turn = newTurnInBuildPhase(p2);
 
         int vertexId = 2;
         int edgeId = 4;
@@ -794,7 +801,7 @@ public class TurnTest {
         p3.addResources(ResourceType.LUMBER, 1);
         p3.addResources(ResourceType.WOOL, 1);
         p3.addResources(ResourceType.GRAIN, 1);
-        Turn turn = new Turn(game, p3, dice, bank);
+        Turn turn = newTurnInBuildPhase(p3);
 
         int vertexId = 2;
         int edgeId = 4;
@@ -816,7 +823,7 @@ public class TurnTest {
         p3.addResources(ResourceType.LUMBER, 1);
         p3.addResources(ResourceType.WOOL, 1);
         p3.addResources(ResourceType.GRAIN, 1);
-        Turn turn = new Turn(game, p3, dice, bank);
+        Turn turn = newTurnInBuildPhase(p3);
 
         int vertexId = 2;
 
@@ -831,7 +838,7 @@ public class TurnTest {
         p3.addResources(ResourceType.LUMBER, 1);
         p3.addResources(ResourceType.WOOL, 1);
         p3.addResources(ResourceType.GRAIN, 1);
-        Turn turn = new Turn(game, p3, dice, bank);
+        Turn turn = newTurnInBuildPhase(p3);
 
         int vertexId = 33;
         int edgeId1 = 39;
@@ -852,7 +859,7 @@ public class TurnTest {
         p3.addResources(ResourceType.LUMBER, 1);
         p3.addResources(ResourceType.WOOL, 1);
         p3.addResources(ResourceType.GRAIN, 1);
-        Turn turn = new Turn(game, p3, dice, bank);
+        Turn turn = newTurnInBuildPhase(p3);
 
         int vertexId = 2;
         int edgeId = 4;
@@ -871,7 +878,7 @@ public class TurnTest {
         p3.addResources(ResourceType.LUMBER, 1);
         p3.addResources(ResourceType.WOOL, 1);
         p3.addResources(ResourceType.GRAIN, 1);
-        Turn turn = new Turn(game, p3, dice, bank);
+        Turn turn = newTurnInBuildPhase(p3);
 
         int vertexId = 2;
         int edgeId = 4;
@@ -889,7 +896,7 @@ public class TurnTest {
         p3.addResources(ResourceType.LUMBER, 1);
         p3.addResources(ResourceType.WOOL, 1);
         p3.addResources(ResourceType.GRAIN, 1);
-        Turn turn = new Turn(game, p3, dice, bank);
+        Turn turn = newTurnInBuildPhase(p3);
 
         int vertexId = 2;
         int edgeId = 4;
@@ -908,7 +915,7 @@ public class TurnTest {
         p3.addResources(ResourceType.LUMBER, 1);
         p3.addResources(ResourceType.WOOL, 1);
         p3.addResources(ResourceType.GRAIN, 1);
-        Turn turn = new Turn(game, p3, dice, bank);
+        Turn turn = newTurnInBuildPhase(p3);
 
         int vertexId = 2;
         int edgeId = 4;
@@ -927,7 +934,7 @@ public class TurnTest {
         p3.addResources(ResourceType.LUMBER, 1);
         p3.addResources(ResourceType.WOOL, 1);
         p3.addResources(ResourceType.GRAIN, 1);
-        Turn turn = new Turn(game, p3, dice, bank);
+        Turn turn = newTurnInBuildPhase(p3);
 
         int vertexId = 2;
         int edgeId = 4;
@@ -945,7 +952,7 @@ public class TurnTest {
         p3.addResources(ResourceType.LUMBER, 1);
         p3.addResources(ResourceType.WOOL, 1);
         p3.addResources(ResourceType.GRAIN, 1);
-        Turn turn = new Turn(game, p3, dice, bank);
+        Turn turn = newTurnInBuildPhase(p3);
 
         for (int i = 10; i < 15; i++) {
             game.getBoard().getVertex(i).setOwner(p3);
@@ -966,7 +973,7 @@ public class TurnTest {
         p3.addResources(ResourceType.LUMBER, 1);
         p3.addResources(ResourceType.WOOL, 1);
         p3.addResources(ResourceType.GRAIN, 1);
-        Turn turn = new Turn(game, p3, dice, bank);
+        Turn turn = newTurnInBuildPhase(p3);
 
         for (int i = 10; i < 14; i++) {
             game.getBoard().getVertex(i).setOwner(p3);
@@ -999,7 +1006,7 @@ public class TurnTest {
     public void BuildCity_PlayerDoesNotHaveEnoughOre_ThrowsIllegalStateException() {
         p3.addResources(ResourceType.ORE, 2);
         p3.addResources(ResourceType.GRAIN, 2);
-        Turn turn = new Turn(game, p3, dice, bank);
+        Turn turn = newTurnInBuildPhase(p3);
 
         int vertexId = 2;
         game.getBoard().getVertex(vertexId).setOwner(p3);
@@ -1013,7 +1020,7 @@ public class TurnTest {
     public void BuildCity_PlayerDoesNotHaveEnoughGrain_ThrowsIllegalStateException() {
         p3.addResources(ResourceType.ORE, 3);
         p3.addResources(ResourceType.GRAIN, 1);
-        Turn turn = new Turn(game, p3, dice, bank);
+        Turn turn = newTurnInBuildPhase(p3);
 
         int vertexId = 2;
         game.getBoard().getVertex(vertexId).setOwner(p3);
@@ -1027,7 +1034,7 @@ public class TurnTest {
     public void BuildCity_PlayerHasExactAmountOfEachRequiredResource_NoExceptionThrown() {
         p3.addResources(ResourceType.ORE, 3);
         p3.addResources(ResourceType.GRAIN, 2);
-        Turn turn = new Turn(game, p3, dice, bank);
+        Turn turn = newTurnInBuildPhase(p3);
 
         int vertexId = 2;
         game.getBoard().getVertex(vertexId).setOwner(p3);
@@ -1044,7 +1051,7 @@ public class TurnTest {
     public void BuildCity_PlayerHasFourCities_ThrowsIllegalStateException() {
         p3.addResources(ResourceType.ORE, 3);
         p3.addResources(ResourceType.GRAIN, 2);
-        Turn turn = new Turn(game, p3, dice, bank);
+        Turn turn = newTurnInBuildPhase(p3);
 
         for (int i = 10; i < 14; i++) {
             game.getBoard().getVertex(i).setOwner(p3);
@@ -1063,7 +1070,7 @@ public class TurnTest {
     public void BuildCity_PlayerHasThreeCities_NoExceptionThrown() {
         p3.addResources(ResourceType.ORE, 3);
         p3.addResources(ResourceType.GRAIN, 2);
-        Turn turn = new Turn(game, p3, dice, bank);
+        Turn turn = newTurnInBuildPhase(p3);
 
         for (int i = 10; i < 13; i++) {
             game.getBoard().getVertex(i).setOwner(p3);
@@ -1085,7 +1092,7 @@ public class TurnTest {
     public void BuildCity_PlayerDoesNotHaveExistingSettlement_ThrowsIllegalStateException() {
         p3.addResources(ResourceType.ORE, 3);
         p3.addResources(ResourceType.GRAIN, 2);
-        Turn turn = new Turn(game, p3, dice, bank);
+        Turn turn = newTurnInBuildPhase(p3);
 
         int vertexId = 2;
 
@@ -1098,7 +1105,7 @@ public class TurnTest {
     public void BuildCity_VertexOccupiedByEnemySettlement_ThrowsIllegalStateException() {
         p3.addResources(ResourceType.ORE, 3);
         p3.addResources(ResourceType.GRAIN, 2);
-        Turn turn = new Turn(game, p3, dice, bank);
+        Turn turn = newTurnInBuildPhase(p3);
 
         int vertexId = 2;
         game.getBoard().getVertex(vertexId).setOwner(p4);
@@ -1112,7 +1119,7 @@ public class TurnTest {
     public void BuildCity_VertexOccupiedByEnemyCity_ThrowsIllegalStateException() {
         p3.addResources(ResourceType.ORE, 3);
         p3.addResources(ResourceType.GRAIN, 2);
-        Turn turn = new Turn(game, p3, dice, bank);
+        Turn turn = newTurnInBuildPhase(p3);
 
         int vertexId = 2;
         game.getBoard().getVertex(vertexId).setOwner(p4);
@@ -1127,7 +1134,7 @@ public class TurnTest {
     public void BuildCity_VertexOccupiedByOwnCity_ThrowsIllegalStateException() {
         p3.addResources(ResourceType.ORE, 3);
         p3.addResources(ResourceType.GRAIN, 2);
-        Turn turn = new Turn(game, p3, dice, bank);
+        Turn turn = newTurnInBuildPhase(p3);
 
         int vertexId = 2;
         game.getBoard().getVertex(vertexId).setOwner(p3);
@@ -1142,7 +1149,7 @@ public class TurnTest {
     public void BuildCity_VertexOccupiedByOwnSettlement_NoExceptionThrown() {
         p3.addResources(ResourceType.ORE, 3);
         p3.addResources(ResourceType.GRAIN, 2);
-        Turn turn = new Turn(game, p3, dice, bank);
+        Turn turn = newTurnInBuildPhase(p3);
 
         int vertexId = 2;
         game.getBoard().getVertex(vertexId).setOwner(p3);

--- a/src/test/java/domain/TurnTest.java
+++ b/src/test/java/domain/TurnTest.java
@@ -1361,6 +1361,46 @@ public class TurnTest {
 
         assertEquals(Optional.of(offer), turn.getPendingTrade());
     }
+
+    @Test
+    public void SubmitMaritimeTrade_OutsideTradePhase_ThrowsIllegalStateException() {
+        p1.addResources(ResourceType.BRICK, 4);
+        Turn turn = newTurnInBuildPhase(p1);
+        MaritimeTrade trade = new MaritimeTrade(p1, ResourceType.BRICK, 4, ResourceType.WOOL, board);
+
+        assertThrows(IllegalStateException.class, () -> turn.submitMaritimeTrade(trade));
+    }
+
+    @Test
+    public void SubmitMaritimeTrade_BankHasNoneOfReceivingResource_ThrowsIllegalStateException() {
+        p1.addResources(ResourceType.BRICK, 4);
+        DiceRoll fixedDice = mockDiceRoll(4, 4);
+        Turn turn = new Turn(game, p1, fixedDice, bank);
+        turn.rollDice();
+        MaritimeTrade trade = new MaritimeTrade(p1, ResourceType.BRICK, 4, ResourceType.WOOL, board);
+
+        assertThrows(IllegalStateException.class, () -> turn.submitMaritimeTrade(trade));
+    }
+
+    @Test
+    public void SubmitMaritimeTrade_BankHasExactlyOneOfReceivingResource_ExecutesTrade() {
+        p1.addResources(ResourceType.BRICK, 4);
+        bank.collect(ResourceType.WOOL, 1);
+        DiceRoll fixedDice = mockDiceRoll(4, 4);
+        Turn turn = new Turn(game, p1, fixedDice, bank);
+        turn.rollDice();
+        int bankBrickBefore = bank.getResourceCount(ResourceType.BRICK);
+        MaritimeTrade trade = new MaritimeTrade(p1, ResourceType.BRICK, 4, ResourceType.WOOL, board);
+
+        turn.submitMaritimeTrade(trade);
+
+        assertAll(
+                () -> assertEquals(0, p1.getResourceCount(ResourceType.BRICK)),
+                () -> assertEquals(1, p1.getResourceCount(ResourceType.WOOL)),
+                () -> assertEquals(bankBrickBefore + 4, bank.getResourceCount(ResourceType.BRICK)),
+                () -> assertEquals(0, bank.getResourceCount(ResourceType.WOOL))
+        );
+    }
 }
 
 

--- a/src/test/java/domain/TurnTest.java
+++ b/src/test/java/domain/TurnTest.java
@@ -102,6 +102,108 @@ public class TurnTest {
         assertEquals(expected, turn.getPhase());
     }
 
+    private DiceRoll mockDiceRoll(int die1Value, int die2Value) {
+        Random mockRandom = EasyMock.createMock(Random.class);
+        EasyMock.expect(mockRandom.nextInt(6)).andReturn(die1Value - 1).andReturn(die2Value - 1);
+        EasyMock.replay(mockRandom);
+        return new DiceRoll(mockRandom);
+    }
+
+    private Vertex findVertexAdjacentToNumber(int number) {
+        for (Vertex vertex : board.getVertices()) {
+            for (Hex hex : vertex.getAdjacentHexes()) {
+                if (hex.getNumberToken() == number && hex.producesResource()) {
+                    return vertex;
+                }
+            }
+        }
+        throw new IllegalStateException("No vertex found adjacent to a hex with number token " + number);
+    }
+
+    @Test
+    public void RollDice_ValidCall_ReturnsRollValue() {
+        DiceRoll fixedDice = mockDiceRoll(4, 4);
+        Turn turn = new Turn(game, p1, fixedDice, bank);
+
+        assertEquals(8, turn.rollDice());
+    }
+
+    @Test
+    public void RollDice_ValidCall_AdvancesPhaseToTrade() {
+        DiceRoll fixedDice = mockDiceRoll(4, 4);
+        Turn turn = new Turn(game, p1, fixedDice, bank);
+
+        turn.rollDice();
+
+        assertEquals(TurnPhase.TRADE, turn.getPhase());
+    }
+
+    @Test
+    public void RollDice_CalledOutsideProductionPhase_ThrowsIllegalStateException() {
+        DiceRoll fixedDice = mockDiceRoll(4, 4);
+        Turn turn = new Turn(game, p1, fixedDice, bank);
+
+        turn.rollDice();
+
+        assertThrows(IllegalStateException.class, turn::rollDice);
+    }
+
+    @Test
+    public void RollDice_NonSevenRoll_DistributesResourcesToSettlementOwner() {
+        Vertex vertex = findVertexAdjacentToNumber(8);
+        vertex.setOwner(p1);
+        ResourceType expectedResource = vertex.getAdjacentHexes().stream()
+                .filter(hex -> hex.getNumberToken() == 8 && hex.producesResource())
+                .findFirst().get().getTerrainType().getResourceType();
+
+        DiceRoll fixedDice = mockDiceRoll(4, 4);
+        Turn turn = new Turn(game, p1, fixedDice, bank);
+
+        turn.rollDice();
+
+        assertTrue(p1.getResourceCount(expectedResource) > 0);
+    }
+
+    @Test
+    public void RollDice_RollOfSeven_NoResourcesDistributed() {
+        Vertex vertex = findVertexAdjacentToNumber(8);
+        vertex.setOwner(p1);
+
+        DiceRoll sevenDice = mockDiceRoll(3, 4);
+        Turn turn = new Turn(game, p1, sevenDice, bank);
+
+        turn.rollDice();
+
+        assertEquals(0, p1.getTotalResourceCount());
+    }
+
+    @Test
+    public void IsSevenRolled_BeforeRollingDice_ReturnsFalse() {
+        Turn turn = new Turn(game, p1, dice, bank);
+
+        assertFalse(turn.isSevenRolled());
+    }
+
+    @Test
+    public void IsSevenRolled_AfterRollingSeven_ReturnsTrue() {
+        DiceRoll sevenDice = mockDiceRoll(3, 4);
+        Turn turn = new Turn(game, p1, sevenDice, bank);
+
+        turn.rollDice();
+
+        assertTrue(turn.isSevenRolled());
+    }
+
+    @Test
+    public void IsSevenRolled_AfterRollingNonSeven_ReturnsFalse() {
+        DiceRoll fixedDice = mockDiceRoll(4, 4);
+        Turn turn = new Turn(game, p1, fixedDice, bank);
+
+        turn.rollDice();
+
+        assertFalse(turn.isSevenRolled());
+    }
+
     @Test
     public void BuildRoad_PlayerDoesNotHaveBrick_ThrowsIllegalStateException() {
         p2.addResources(ResourceType.LUMBER, 1);

--- a/src/test/java/domain/TurnTest.java
+++ b/src/test/java/domain/TurnTest.java
@@ -523,6 +523,18 @@ public class TurnTest {
     }
 
     @Test
+    public void BuildRoad_OutsideBuildPhase_ThrowsIllegalStateException() {
+        p3.addResources(ResourceType.BRICK, 1);
+        p3.addResources(ResourceType.LUMBER, 1);
+        Turn turn = new Turn(game, p3, dice, bank);
+
+        int edgeId = 2;
+        game.getBoard().getEdge(edgeId).getEndpoints().get(0).setOwner(p3);
+
+        assertThrows(IllegalStateException.class, () -> turn.buildRoad(edgeId));
+    }
+
+    @Test
     public void BuildRoad_PlayerDoesNotHaveBrick_ThrowsIllegalStateException() {
         p2.addResources(ResourceType.LUMBER, 1);
         Turn turn = new Turn(game, p2, dice, bank);
@@ -695,6 +707,21 @@ public class TurnTest {
         assertThrows(IllegalStateException.class, () -> {
             turn.buildRoad(edgeId2);
         });
+    }
+
+    @Test
+    public void BuildSettlement_OutsideBuildPhase_ThrowsIllegalStateException() {
+        p3.addResources(ResourceType.BRICK, 1);
+        p3.addResources(ResourceType.LUMBER, 1);
+        p3.addResources(ResourceType.WOOL, 1);
+        p3.addResources(ResourceType.GRAIN, 1);
+        Turn turn = new Turn(game, p3, dice, bank);
+
+        int vertexId = 2;
+        int edgeId = 4;
+        game.getBoard().getEdge(edgeId).setOwner(p3);
+
+        assertThrows(IllegalStateException.class, () -> turn.buildSettlement(vertexId));
     }
 
     @Test
@@ -954,6 +981,18 @@ public class TurnTest {
         });
 
         assertEquals(p3, game.getBoard().getVertex(vertexId).getOwner().orElse(null));
+    }
+
+    @Test
+    public void BuildCity_OutsideBuildPhase_ThrowsIllegalStateException() {
+        p3.addResources(ResourceType.ORE, 3);
+        p3.addResources(ResourceType.GRAIN, 2);
+        Turn turn = new Turn(game, p3, dice, bank);
+
+        int vertexId = 2;
+        game.getBoard().getVertex(vertexId).setOwner(p3);
+
+        assertThrows(IllegalStateException.class, () -> turn.buildCity(vertexId));
     }
 
     @Test


### PR DESCRIPTION
Implements Turn, taking a player through Production, Trade, Build, and Done, with phase rules enforced throughout.

Dice & robber: rollDice() distributes resources on a normal roll, or on a 7 skips production, makes players over 7 cards discard half, and starts a "robber pending" sequence (moveRobber(), steal()) that must be resolved before the turn can continue. Board now tracks the robber's hex, and ResourceProduction skips producing from it. Stealing from an empty-handed target resolves as a no-op rather than getting the turn stuck.

Trade: proposeTrade/acceptTrade/rejectTrade support one pending domestic offer at a time, auto-rejected when the turn moves to Build. submitMaritimeTrade lets the player trade with the bank at their best harbor rate.

Building: buildRoad/buildSettlement/buildCity now require the Build phase.

Development cards: Since the deck and hands persist across turns, ownership moved to Game (shuffled 25-card deck, per-player hands), and Turn delegates to it while handling buyDevelopmentCard/playDevelopmentCard and their constraints.

Closes #44 