### PR TITLE
Implement Development Card Effects

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,8 +10,8 @@ plugins {
 // Add new classes here as they are implemented and tested.
 pitest {
     junit5PluginVersion = "1.2.1"
-    targetClasses = setOf("domain.Board", "domain.Edge", "domain.Vertex", "domain.DiceRoll", "domain.TerrainType", "domain.Bank", "domain.ResourceProduction", "domain.DevelopmentCard", "domain.SpecialCardTracker")
-    targetTests = setOf("domain.BoardTest", "domain.EdgeTest", "domain.VertexTest", "domain.DiceRollTest", "domain.TerrainTypeTest", "domain.BankTest", "domain.ResourceProductionTest", "domain.DevelopmentCardTest", "domain.SpecialCardTrackerTest")
+    targetClasses = setOf("domain.Board", "domain.Edge", "domain.Vertex", "domain.DiceRoll", "domain.TerrainType", "domain.Bank", "domain.ResourceProduction", "domain.DevelopmentCard", "domain.SpecialCardTracker", "domain.Turn")
+    targetTests = setOf("domain.BoardTest", "domain.EdgeTest", "domain.VertexTest", "domain.DiceRollTest", "domain.TerrainTypeTest", "domain.BankTest", "domain.ResourceProductionTest", "domain.DevelopmentCardTest", "domain.SpecialCardTrackerTest", "domain.TurnTest")
     outputFormats = setOf("HTML")
     mutationThreshold = 100
 }

--- a/docs/bva/Turn.md
+++ b/docs/bva/Turn.md
@@ -1,6 +1,6 @@
 # BVA Analysis: Turn
 
-## Method under test: `Turn(Game game, Player activePlayer, Dice dice, Bank bank)`
+## Method under test: `Turn(Game game, Player activePlayer, DiceRoll dice, Bank bank)`
 
 - **TC1: Constructor_WithNullGame_ThrowsIllegalArgumentException** ( :white_check_mark: )
   - State of the system: `game = null`
@@ -440,55 +440,110 @@
   - State of the system: turn is in BUILD phase, active player has exactly 1 Ore + 1 Wool + 1 Grain, exactly 1 card remains in the deck (boundary)
   - Expected output: player's Ore/Wool/Grain counts become `0`, `getRemainingDeckSize()` becomes `0`, and `getPlayerHand(activePlayer)` grows by one card
 
-## Method under test: `playDevelopmentCard(Player player, DevelopmentCard card)`
-
-- **TC98: PlayDevelopmentCard_OutsideTradeOrBuildPhase_ThrowsIllegalStateException** ( :white_check_mark: )
-  - State of the system: turn still in PRODUCTION phase (`rollDice()` not yet called, boundary: one phase before TRADE)
-  - Expected output: `IllegalStateException`
-
-- **TC99: PlayDevelopmentCard_DevCardAlreadyPlayedThisTurn_ThrowsIllegalStateException** ( :white_check_mark: )
-  - State of the system: a (different) development card was already played earlier this turn
-  - Expected output: `IllegalStateException`
-
-- **TC100: PlayDevelopmentCard_NonVictoryPointCardPurchasedThisTurn_ThrowsIllegalStateException** ( :white_check_mark: )
-  - State of the system: card is a non-`VICTORY_POINT` card bought via `buyDevelopmentCard()` earlier in this same turn (boundary)
-  - Expected output: `IllegalStateException`
-
-- **TC101: PlayDevelopmentCard_CardAlreadyPlayed_ThrowsIllegalStateException** ( :white_check_mark: )
-  - State of the system: `card.isPlayed()` is already `true` (acquired and played in a previous turn)
-  - Expected output: `IllegalStateException`
-
-- **TC110: PlayDevelopmentCard_VictoryPointCard_ThrowsIllegalStateException** ( :white_check_mark: )
-  - State of the system: `card` is a `VICTORY_POINT` card in the active player's hand (boundary: the one card type that can never be played through this method — per the rules it is instead privately revealed to declare victory, which requires whole-game VP tracking that is out of scope for a single turn)
-  - Expected output: `IllegalStateException`
-
-- **TC102: PlayDevelopmentCard_UnplayedCardFromPriorTurn_MarksCardAsPlayed** ( :white_check_mark: )
-  - State of the system: turn is in TRADE or BUILD phase, `card` is an unplayed non-`VICTORY_POINT` card the player acquired in a previous turn (boundary: minimal valid preconditions)
-  - Expected output: `card.isPlayed()` becomes `true`
-
 ## Method under test: `getPlayerHand(Player player)`
 
-- **TC103: GetPlayerHand_PlayerWithNoCards_ReturnsEmptyList** ( :white_check_mark: )
+- **TC98: GetPlayerHand_PlayerWithNoCards_ReturnsEmptyList** ( :white_check_mark: )
   - State of the system: `player` has not purchased any development cards (boundary)
   - Expected output: empty list
 
-- **TC104: GetPlayerHand_AfterBuyingOneCard_ReturnsListContainingPurchasedCard** ( :white_check_mark: )
+- **TC99: GetPlayerHand_AfterBuyingOneCard_ReturnsListContainingPurchasedCard** ( :white_check_mark: )
   - State of the system: `player` purchased exactly one development card via `buyDevelopmentCard()` (boundary)
   - Expected output: list of size `1` containing that card
 
-- **TC105: GetPlayerHand_ReturnedList_IsUnmodifiable** ( :white_check_mark: )
+- **TC100: GetPlayerHand_ReturnedList_IsUnmodifiable** ( :white_check_mark: )
   - State of the system: a hand list obtained via `getPlayerHand()`
   - Expected output: `UnsupportedOperationException` on attempted mutation
 
 ## Method under test: `getRemainingDeckSize()`
 
-- **TC106: GetRemainingDeckSize_NewTurn_Returns25** ( :white_check_mark: )
+- **TC101: GetRemainingDeckSize_NewTurn_Returns25** ( :white_check_mark: )
   - State of the system: no cards have been purchased yet this game (boundary: full 14 KNIGHT + 6 Progress + 5 VICTORY_POINT deck)
   - Expected output: `25`
 
-- **TC107: GetRemainingDeckSize_AfterBuyingOneCard_DecreasesByOne** ( :white_check_mark: )
+- **TC102: GetRemainingDeckSize_AfterBuyingOneCard_DecreasesByOne** ( :white_check_mark: )
   - State of the system: exactly one card has been purchased via `buyDevelopmentCard()` (boundary)
   - Expected output: `24`
 
+## Shared validation for dev card play methods
+
+- **TC103: playKnightCard_NullCard_ThrowsIllegalArgumentException** ( not implemented )
+  - State of the system: valid turn in TRADE phase, `card = null`
+  - Expected output: `IllegalArgumentException`
+
+- **TC104: playRoadBuildingCard_WrongPlayer_ThrowsIllegalArgumentException** ( not implemented )
+  - State of the system: valid turn in TRADE phase, `player != activePlayer`
+  - Expected output: `IllegalArgumentException`
+
+- **TC105: playYearOfPlenty_WrongPhase_ThrowsIllegalStateException** ( not implemented )
+  - State of the system: turn in PRODUCTION phase, valid card
+  - Expected output: `IllegalStateException`
+
+- **TC106: playMonopoly_AlreadyPlayedDevCard_ThrowsIllegalStateException** ( not implemented )
+  - State of the system: valid turn in TRADE phase, `playedDevCardThisTurn = true`
+  - Expected output: `IllegalStateException`
+
+- **TC107: playKnightCard_PlayerDoesNotOwnCard_ThrowsIllegalArgumentException** ( not implemented )
+  - State of the system: valid turn in TRADE phase, card not in player's hand
+  - Expected output: `IllegalArgumentException`
+
+- **TC108: playRoadBuildingCard_CardPurchasedThisTurn_ThrowsIllegalStateException** ( not implemented )
+  - State of the system: valid turn in TRADE phase, card was purchased this turn
+  - Expected output: `IllegalStateException`
+
+- **TC109: playYearOfPlenty_CardAlreadyPlayed_ThrowsIllegalStateException** ( not implemented )
+  - State of the system: valid turn in TRADE phase, card already played
+  - Expected output: `IllegalStateException`
+
+- **TC110: playMonopoly_VictoryPointCard_ThrowsIllegalStateException** ( not implemented )
+  - State of the system: valid turn in TRADE phase, card is VICTORY_POINT
+  - Expected output: `IllegalStateException`
+
+## Method under test: `playKnightCard(Player, DevelopmentCard)`
+
+- **TC110: playKnightCard_NullCard_ThrowsIllegalArgumentException** ( not implemented )
+  - State of the system: valid turn in TRADE phase, `card = null`
+  - Expected output: `IllegalArgumentException`
+
+- **TC111: playKnightCard_ValidCard_SetsRobberPendingMove** ( not implemented )
+  - State of the system: valid turn in TRADE phase, valid KNIGHT card in player's hand
+  - Expected output: robber pending move is set, `moveRobber()` can be called, `card.isPlayed()` returns `true`, second card cannot be played this turn
+
+## Method under test: `playRoadBuildingCard(Player, DevelopmentCard, int, int)`
+
+- **TC112: playRoadBuildingCard_NullCard_ThrowsIllegalArgumentException** ( not implemented )
+  - State of the system: valid turn in TRADE phase, `card = null`
+  - Expected output: `IllegalArgumentException`
+
+- **TC113: playRoadBuildingCard_ValidCard_PlacesTwoFreeRoads** ( not implemented )
+  - State of the system: valid turn in BUILD phase, valid ROAD_BUILDING card in player's hand, two valid edge IDs
+  - Expected output: two roads placed, player resources unchanged, `card.isPlayed()` returns `true`, second card cannot be played this turn
+
+## Method under test: `playYearOfPlenty(Player, DevelopmentCard, ResourceType, ResourceType)`
+
+- **TC114: playYearOfPlenty_NullCard_ThrowsIllegalArgumentException** ( not implemented )
+  - State of the system: valid turn in TRADE phase, `card = null`
+  - Expected output: `IllegalArgumentException`
+
+- **TC115: playYearOfPlenty_ValidCard_GivesTwoResources** ( not implemented )
+  - State of the system: valid turn in TRADE phase, valid YEAR_OF_PLENTY card in player's hand, bank has resources
+  - Expected output: player receives 1 of r1 and 1 of r2, bank decremented accordingly, `card.isPlayed()` returns `true`, second card cannot be played this turn
+
+- **TC116: playYearOfPlenty_BankEmpty_ThrowsIllegalStateException** ( not implemented )
+  - State of the system: valid turn in TRADE phase, valid YEAR_OF_PLENTY card, bank has 0 of requested resource
+  - Expected output: `IllegalStateException`
+
+## Method under test: `playMonopoly(Player, DevelopmentCard, ResourceType)`
+
+- **TC117: playMonopoly_NullCard_ThrowsIllegalArgumentException** ( not implemented )
+  - State of the system: valid turn in TRADE phase, `card = null`
+  - Expected output: `IllegalArgumentException`
+
+- **TC118: playMonopoly_ValidCard_TakesAllResourceFromOtherPlayers** ( not implemented )
+  - State of the system: valid turn in TRADE phase, valid MONOPOLY card, other players have BRICK
+  - Expected output: active player receives all BRICK from other players, other players have 0 BRICK, `card.isPlayed()` returns `true`, second card cannot be played this turn
+
+- **TC119: playMonopoly_OtherPlayersHaveNone_NoChange** ( not implemented )
+  - State of the system: valid turn in TRADE phase, valid MONOPOLY card, other players have 0 of resource
+  - Expected output: no resources transferred, no exception thrown
 
 

--- a/docs/bva/Turn.md
+++ b/docs/bva/Turn.md
@@ -466,83 +466,67 @@
 
 ## Shared validation for dev card play methods
 
-- **TC103: playKnightCard_NullCard_ThrowsIllegalArgumentException** ( not implemented )
+- **TC103: playKnightCard_NullCard_ThrowsIllegalArgumentException** ( :white_check_mark: )
   - State of the system: valid turn in TRADE phase, `card = null`
   - Expected output: `IllegalArgumentException`
 
-- **TC104: playRoadBuildingCard_WrongPlayer_ThrowsIllegalArgumentException** ( not implemented )
+- **TC104: playRoadBuildingCard_WrongPlayer_ThrowsIllegalArgumentException** ( :white_check_mark: )
   - State of the system: valid turn in TRADE phase, `player != activePlayer`
   - Expected output: `IllegalArgumentException`
 
-- **TC105: playYearOfPlenty_WrongPhase_ThrowsIllegalStateException** ( not implemented )
+- **TC105: playYearOfPlenty_WrongPhase_ThrowsIllegalStateException** ( :white_check_mark: )
   - State of the system: turn in PRODUCTION phase, valid card
   - Expected output: `IllegalStateException`
 
-- **TC106: playMonopoly_AlreadyPlayedDevCard_ThrowsIllegalStateException** ( not implemented )
+- **TC106: playMonopoly_AlreadyPlayedDevCard_ThrowsIllegalStateException** ( :white_check_mark: )
   - State of the system: valid turn in TRADE phase, `playedDevCardThisTurn = true`
   - Expected output: `IllegalStateException`
 
-- **TC107: playKnightCard_PlayerDoesNotOwnCard_ThrowsIllegalArgumentException** ( not implemented )
+- **TC107: playKnightCard_PlayerDoesNotOwnCard_ThrowsIllegalArgumentException** ( :white_check_mark: )
   - State of the system: valid turn in TRADE phase, card not in player's hand
   - Expected output: `IllegalArgumentException`
 
-- **TC108: playRoadBuildingCard_CardPurchasedThisTurn_ThrowsIllegalStateException** ( not implemented )
+- **TC108: playRoadBuildingCard_CardPurchasedThisTurn_ThrowsIllegalStateException** ( :white_check_mark: )
   - State of the system: valid turn in TRADE phase, card was purchased this turn
   - Expected output: `IllegalStateException`
 
-- **TC109: playYearOfPlenty_CardAlreadyPlayed_ThrowsIllegalStateException** ( not implemented )
+- **TC109: playYearOfPlenty_CardAlreadyPlayed_ThrowsIllegalStateException** ( :white_check_mark: )
   - State of the system: valid turn in TRADE phase, card already played
   - Expected output: `IllegalStateException`
 
-- **TC110: playMonopoly_VictoryPointCard_ThrowsIllegalStateException** ( not implemented )
+- **TC110: playMonopoly_VictoryPointCard_ThrowsIllegalStateException** ( :white_check_mark: )
   - State of the system: valid turn in TRADE phase, card is VICTORY_POINT
   - Expected output: `IllegalStateException`
 
 ## Method under test: `playKnightCard(Player, DevelopmentCard)`
 
-- **TC110: playKnightCard_NullCard_ThrowsIllegalArgumentException** ( not implemented )
-  - State of the system: valid turn in TRADE phase, `card = null`
-  - Expected output: `IllegalArgumentException`
-
-- **TC111: playKnightCard_ValidCard_SetsRobberPendingMove** ( not implemented )
+- **TC111: playKnightCard_ValidCard_SetsRobberPendingMove** ( :white_check_mark: )
   - State of the system: valid turn in TRADE phase, valid KNIGHT card in player's hand
   - Expected output: robber pending move is set, `moveRobber()` can be called, `card.isPlayed()` returns `true`, second card cannot be played this turn
 
 ## Method under test: `playRoadBuildingCard(Player, DevelopmentCard, int, int)`
 
-- **TC112: playRoadBuildingCard_NullCard_ThrowsIllegalArgumentException** ( not implemented )
-  - State of the system: valid turn in TRADE phase, `card = null`
-  - Expected output: `IllegalArgumentException`
-
-- **TC113: playRoadBuildingCard_ValidCard_PlacesTwoFreeRoads** ( not implemented )
+- **TC112: playRoadBuildingCard_ValidCard_PlacesTwoFreeRoads** ( :white_check_mark: )
   - State of the system: valid turn in BUILD phase, valid ROAD_BUILDING card in player's hand, two valid edge IDs
   - Expected output: two roads placed, player resources unchanged, `card.isPlayed()` returns `true`, second card cannot be played this turn
 
 ## Method under test: `playYearOfPlenty(Player, DevelopmentCard, ResourceType, ResourceType)`
 
-- **TC114: playYearOfPlenty_NullCard_ThrowsIllegalArgumentException** ( not implemented )
-  - State of the system: valid turn in TRADE phase, `card = null`
-  - Expected output: `IllegalArgumentException`
-
-- **TC115: playYearOfPlenty_ValidCard_GivesTwoResources** ( not implemented )
+- **TC113: playYearOfPlenty_ValidCard_GivesTwoResources** ( :white_check_mark: )
   - State of the system: valid turn in TRADE phase, valid YEAR_OF_PLENTY card in player's hand, bank has resources
   - Expected output: player receives 1 of r1 and 1 of r2, bank decremented accordingly, `card.isPlayed()` returns `true`, second card cannot be played this turn
 
-- **TC116: playYearOfPlenty_BankEmpty_ThrowsIllegalArgumentException** ( not implemented )
+- **TC114: playYearOfPlenty_BankEmpty_ThrowsIllegalArgumentException** ( :white_check_mark: )
   - State of the system: valid turn in TRADE phase, valid YEAR_OF_PLENTY card, bank has 0 of requested resource
   - Expected output: `IllegalArgumentException`
 
 ## Method under test: `playMonopoly(Player, DevelopmentCard, ResourceType)`
 
-- **TC117: playMonopoly_NullCard_ThrowsIllegalArgumentException** ( not implemented )
-  - State of the system: valid turn in TRADE phase, `card = null`
-  - Expected output: `IllegalArgumentException`
-
-- **TC118: playMonopoly_ValidCard_TakesAllResourceFromOtherPlayers** ( not implemented )
+- **TC115: playMonopoly_ValidCard_TakesAllResourceFromOtherPlayers** ( :white_check_mark: )
   - State of the system: valid turn in TRADE phase, valid MONOPOLY card, other players have BRICK
   - Expected output: active player receives all BRICK from other players, other players have 0 BRICK, `card.isPlayed()` returns `true`, second card cannot be played this turn
 
-- **TC119: playMonopoly_OtherPlayersHaveNone_NoChange** ( not implemented )
+- **TC116: playMonopoly_OtherPlayersHaveNone_NoChange** ( :white_check_mark: )
   - State of the system: valid turn in TRADE phase, valid MONOPOLY card, other players have 0 of resource
   - Expected output: no resources transferred, no exception thrown
 

--- a/docs/bva/Turn.md
+++ b/docs/bva/Turn.md
@@ -528,9 +528,9 @@
   - State of the system: valid turn in TRADE phase, valid YEAR_OF_PLENTY card in player's hand, bank has resources
   - Expected output: player receives 1 of r1 and 1 of r2, bank decremented accordingly, `card.isPlayed()` returns `true`, second card cannot be played this turn
 
-- **TC116: playYearOfPlenty_BankEmpty_ThrowsIllegalStateException** ( not implemented )
+- **TC116: playYearOfPlenty_BankEmpty_ThrowsIllegalArgumentException** ( not implemented )
   - State of the system: valid turn in TRADE phase, valid YEAR_OF_PLENTY card, bank has 0 of requested resource
-  - Expected output: `IllegalStateException`
+  - Expected output: `IllegalArgumentException`
 
 ## Method under test: `playMonopoly(Player, DevelopmentCard, ResourceType)`
 

--- a/src/main/java/domain/BuildManager.java
+++ b/src/main/java/domain/BuildManager.java
@@ -181,4 +181,13 @@ public class BuildManager {
         }
         return cityCount;
     }
+
+    public void buildFreeRoad(int edgeId) {
+        Board board = game.getBoard();
+        Edge edge = board.getEdge(edgeId);
+        Vertex endpoint1 = edge.getEndpoints().get(0);
+        Vertex endpoint2 = edge.getEndpoints().get(1);
+        validateRoadConditions(edge, endpoint1, endpoint2, board);
+        edge.setOwner(activePlayer);
+    }
 }

--- a/src/main/java/domain/Turn.java
+++ b/src/main/java/domain/Turn.java
@@ -400,6 +400,9 @@ public class Turn {
         if (playedDevCardThisTurn) {
             throw new IllegalStateException("Only one development card can be played per turn");
         }
+        if (!game.getPlayerHand(player).contains(card)) {
+            throw new IllegalArgumentException("Player does not own this development card");
+        }
     }
 
     public void playKnightCard(Player player, DevelopmentCard card) {

--- a/src/main/java/domain/Turn.java
+++ b/src/main/java/domain/Turn.java
@@ -397,10 +397,14 @@ public class Turn {
         if (phase != TurnPhase.TRADE && phase != TurnPhase.BUILD) {
             throw new IllegalStateException("Development cards can only be played during the trade or build phase");
         }
+        if (playedDevCardThisTurn) {
+            throw new IllegalStateException("Only one development card can be played per turn");
+        }
     }
 
     public void playKnightCard(Player player, DevelopmentCard card) {
         validateDevCardPlay(player, card);
+        playedDevCardThisTurn = true;
     }
 
     public void playRoadBuildingCard(Player player, DevelopmentCard card, int edgeId1, int edgeId2) {
@@ -408,6 +412,10 @@ public class Turn {
     }
 
     public void playYearOfPlenty(Player player, DevelopmentCard card, ResourceType r1, ResourceType r2) {
+        validateDevCardPlay(player, card);
+    }
+
+    public void playMonopoly(Player player, DevelopmentCard card, ResourceType resource) {
         validateDevCardPlay(player, card);
     }
 }

--- a/src/main/java/domain/Turn.java
+++ b/src/main/java/domain/Turn.java
@@ -443,5 +443,15 @@ public class Turn {
 
     public void playMonopoly(Player player, DevelopmentCard card, ResourceType resource) {
         validateDevCardPlay(player, card);
+        executeDevCardPlay(card);
+        for (Player p : game.getPlayers()) {
+            if (p != activePlayer) {
+                int amount = p.getResourceCount(resource);
+                if (amount > 0) {
+                    p.removeResources(resource, amount);
+                    activePlayer.addResources(resource, amount);
+                }
+            }
+        }
     }
 }

--- a/src/main/java/domain/Turn.java
+++ b/src/main/java/domain/Turn.java
@@ -394,6 +394,9 @@ public class Turn {
         if (player != activePlayer) {
             throw new IllegalArgumentException("Only the active player can play a development card");
         }
+        if (phase != TurnPhase.TRADE && phase != TurnPhase.BUILD) {
+            throw new IllegalStateException("Development cards can only be played during the trade or build phase");
+        }
     }
 
     public void playKnightCard(Player player, DevelopmentCard card) {
@@ -401,6 +404,10 @@ public class Turn {
     }
 
     public void playRoadBuildingCard(Player player, DevelopmentCard card, int edgeId1, int edgeId2) {
+        validateDevCardPlay(player, card);
+    }
+
+    public void playYearOfPlenty(Player player, DevelopmentCard card, ResourceType r1, ResourceType r2) {
         validateDevCardPlay(player, card);
     }
 }

--- a/src/main/java/domain/Turn.java
+++ b/src/main/java/domain/Turn.java
@@ -434,6 +434,11 @@ public class Turn {
 
     public void playYearOfPlenty(Player player, DevelopmentCard card, ResourceType r1, ResourceType r2) {
         validateDevCardPlay(player, card);
+        executeDevCardPlay(card);
+        bank.deduct(r1, 1);
+        bank.deduct(r2, 1);
+        activePlayer.addResources(r1, 1);
+        activePlayer.addResources(r2, 1);
     }
 
     public void playMonopoly(Player player, DevelopmentCard card, ResourceType resource) {

--- a/src/main/java/domain/Turn.java
+++ b/src/main/java/domain/Turn.java
@@ -414,9 +414,15 @@ public class Turn {
         }
     }
 
+    private void executeDevCardPlay(DevelopmentCard card) {
+        card.markAsPlayed();
+        playedDevCardThisTurn = true;
+    }
+
     public void playKnightCard(Player player, DevelopmentCard card) {
         validateDevCardPlay(player, card);
-        playedDevCardThisTurn = true;
+        executeDevCardPlay(card);
+        robberPendingMove = true;
     }
 
     public void playRoadBuildingCard(Player player, DevelopmentCard card, int edgeId1, int edgeId2) {

--- a/src/main/java/domain/Turn.java
+++ b/src/main/java/domain/Turn.java
@@ -409,6 +409,9 @@ public class Turn {
         if (card.isPlayed()) {
             throw new IllegalStateException("This development card has already been played");
         }
+        if (card.getType() == DevelopmentCardType.VICTORY_POINT) {
+            throw new IllegalStateException("Victory Point cards cannot be played");
+        }
     }
 
     public void playKnightCard(Player player, DevelopmentCard card) {

--- a/src/main/java/domain/Turn.java
+++ b/src/main/java/domain/Turn.java
@@ -379,42 +379,17 @@ public class Turn {
         cardsPurchasedThisTurn.add(card);
     }
 
-    public void playDevelopmentCard(Player player, DevelopmentCard card) {
-        if (card == null) {
-            throw new IllegalArgumentException("Development card cannot be null");
-        }
-        if (player != activePlayer) {
-            throw new IllegalArgumentException("Only the active player can play a development card");
-        }
-        if (phase != TurnPhase.TRADE && phase != TurnPhase.BUILD) {
-            throw new IllegalStateException("Development cards can only be played during the trade or build phase");
-        }
-        validateRobberResolved();
-        if (card.getType() == DevelopmentCardType.VICTORY_POINT) {
-            throw new IllegalStateException("Victory Point cards cannot be played");
-        }
-        if (playedDevCardThisTurn) {
-            throw new IllegalStateException("Only one development card can be played per turn");
-        }
-        if (!game.getPlayerHand(player).contains(card)) {
-            throw new IllegalArgumentException("Player does not own this development card");
-        }
-        if (cardsPurchasedThisTurn.contains(card)) {
-            throw new IllegalStateException("A development card cannot be played the same turn it was purchased");
-        }
-        if (card.isPlayed()) {
-            throw new IllegalStateException("This development card has already been played");
-        }
-
-        card.markAsPlayed();
-        playedDevCardThisTurn = true;
-    }
-
     public List<DevelopmentCard> getPlayerHand(Player player) {
         return game.getPlayerHand(player);
     }
 
     public int getRemainingDeckSize() {
         return game.getRemainingDevelopmentCardCount();
+    }
+
+    public void playKnightCard(Player player, DevelopmentCard card) {
+        if (card == null) {
+            throw new IllegalArgumentException("Development card cannot be null");
+        }
     }
 }

--- a/src/main/java/domain/Turn.java
+++ b/src/main/java/domain/Turn.java
@@ -403,6 +403,9 @@ public class Turn {
         if (!game.getPlayerHand(player).contains(card)) {
             throw new IllegalArgumentException("Player does not own this development card");
         }
+        if (cardsPurchasedThisTurn.contains(card)) {
+            throw new IllegalStateException("A development card cannot be played the same turn it was purchased");
+        }
     }
 
     public void playKnightCard(Player player, DevelopmentCard card) {

--- a/src/main/java/domain/Turn.java
+++ b/src/main/java/domain/Turn.java
@@ -387,9 +387,20 @@ public class Turn {
         return game.getRemainingDevelopmentCardCount();
     }
 
-    public void playKnightCard(Player player, DevelopmentCard card) {
+    private void validateDevCardPlay(Player player, DevelopmentCard card) {
         if (card == null) {
             throw new IllegalArgumentException("Development card cannot be null");
         }
+        if (player != activePlayer) {
+            throw new IllegalArgumentException("Only the active player can play a development card");
+        }
+    }
+
+    public void playKnightCard(Player player, DevelopmentCard card) {
+        validateDevCardPlay(player, card);
+    }
+
+    public void playRoadBuildingCard(Player player, DevelopmentCard card, int edgeId1, int edgeId2) {
+        validateDevCardPlay(player, card);
     }
 }

--- a/src/main/java/domain/Turn.java
+++ b/src/main/java/domain/Turn.java
@@ -406,6 +406,9 @@ public class Turn {
         if (cardsPurchasedThisTurn.contains(card)) {
             throw new IllegalStateException("A development card cannot be played the same turn it was purchased");
         }
+        if (card.isPlayed()) {
+            throw new IllegalStateException("This development card has already been played");
+        }
     }
 
     public void playKnightCard(Player player, DevelopmentCard card) {

--- a/src/main/java/domain/Turn.java
+++ b/src/main/java/domain/Turn.java
@@ -427,6 +427,9 @@ public class Turn {
 
     public void playRoadBuildingCard(Player player, DevelopmentCard card, int edgeId1, int edgeId2) {
         validateDevCardPlay(player, card);
+        executeDevCardPlay(card);
+        buildManager.buildFreeRoad(edgeId1);
+        buildManager.buildFreeRoad(edgeId2);
     }
 
     public void playYearOfPlenty(Player player, DevelopmentCard card, ResourceType r1, ResourceType r2) {

--- a/src/main/java/domain/Turn.java
+++ b/src/main/java/domain/Turn.java
@@ -447,10 +447,8 @@ public class Turn {
         for (Player p : game.getPlayers()) {
             if (p != activePlayer) {
                 int amount = p.getResourceCount(resource);
-                if (amount > 0) {
-                    p.removeResources(resource, amount);
-                    activePlayer.addResources(resource, amount);
-                }
+                p.removeResources(resource, amount);
+                activePlayer.addResources(resource, amount);
             }
         }
     }

--- a/src/test/java/domain/TurnTest.java
+++ b/src/test/java/domain/TurnTest.java
@@ -1697,6 +1697,23 @@ public class TurnTest {
                 () -> turn.playMonopoly(p1, card, ResourceType.BRICK));
         assertEquals("Victory Point cards cannot be played", exception.getMessage());
     }
+
+    @Test
+    void playKnightCard_ValidCard_SetsRobberPendingMove() {
+        DiceRoll fixedDice = mockDiceRoll(4, 4);
+        Turn turn = new Turn(game, p1, fixedDice, bank);
+        turn.rollDice();
+        DevelopmentCard card = new DevelopmentCard(DevelopmentCardType.KNIGHT);
+        game.addDevelopmentCardToHand(p1, card);
+
+        turn.playKnightCard(p1, card);
+
+        assertAll(
+                () -> assertTrue(card.isPlayed()),
+                () -> assertThrows(IllegalStateException.class, () -> turn.playKnightCard(p1, new DevelopmentCard(DevelopmentCardType.KNIGHT))),
+                () -> assertDoesNotThrow(() -> turn.moveRobber(1))
+        );
+    }
 }
 
 

--- a/src/test/java/domain/TurnTest.java
+++ b/src/test/java/domain/TurnTest.java
@@ -1670,6 +1670,20 @@ public class TurnTest {
                 () -> turn.playRoadBuildingCard(p1, purchased, 0, 1));
         assertEquals("A development card cannot be played the same turn it was purchased", exception.getMessage());
     }
+
+    @Test
+    void playYearOfPlenty_CardAlreadyPlayed_ThrowsIllegalStateException() {
+        DiceRoll fixedDice = mockDiceRoll(4, 4);
+        Turn turn = new Turn(game, p1, fixedDice, bank);
+        turn.rollDice();
+        DevelopmentCard card = new DevelopmentCard(DevelopmentCardType.YEAR_OF_PLENTY);
+        card.markAsPlayed();
+        game.addDevelopmentCardToHand(p1, card);
+
+        IllegalStateException exception = assertThrows(IllegalStateException.class,
+                () -> turn.playYearOfPlenty(p1, card, ResourceType.BRICK, ResourceType.WOOL));
+        assertEquals("This development card has already been played", exception.getMessage());
+    }
 }
 
 

--- a/src/test/java/domain/TurnTest.java
+++ b/src/test/java/domain/TurnTest.java
@@ -1632,6 +1632,22 @@ public class TurnTest {
                 () -> turn.playYearOfPlenty(p1, card, ResourceType.BRICK, ResourceType.WOOL));
         assertEquals("Development cards can only be played during the trade or build phase", exception.getMessage());
     }
+
+    @Test
+    void playMonopoly_AlreadyPlayedDevCard_ThrowsIllegalStateException() {
+        DiceRoll fixedDice = mockDiceRoll(4, 4);
+        Turn turn = new Turn(game, p1, fixedDice, bank);
+        turn.rollDice();
+        DevelopmentCard first = new DevelopmentCard(DevelopmentCardType.KNIGHT);
+        DevelopmentCard second = new DevelopmentCard(DevelopmentCardType.MONOPOLY);
+        game.addDevelopmentCardToHand(p1, first);
+        game.addDevelopmentCardToHand(p1, second);
+        turn.playKnightCard(p1, first);
+
+        IllegalStateException exception = assertThrows(IllegalStateException.class,
+                () -> turn.playMonopoly(p1, second, ResourceType.BRICK));
+        assertEquals("Only one development card can be played per turn", exception.getMessage());
+    }
 }
 
 

--- a/src/test/java/domain/TurnTest.java
+++ b/src/test/java/domain/TurnTest.java
@@ -1739,6 +1739,32 @@ public class TurnTest {
                 () -> assertThrows(IllegalStateException.class, () -> turn.playKnightCard(p3, new DevelopmentCard(DevelopmentCardType.KNIGHT)))
         );
     }
+
+    @Test
+    void playYearOfPlenty_ValidCard_GivesTwoResources() {
+        Bank freshBank = new Bank();
+        DiceRoll fixedDice = mockDiceRoll(4, 4);
+        Turn turn = new Turn(game, p1, fixedDice, freshBank);
+        turn.rollDice();
+        DevelopmentCard card = new DevelopmentCard(DevelopmentCardType.YEAR_OF_PLENTY);
+        game.addDevelopmentCardToHand(p1, card);
+
+        int brickBefore = p1.getResourceCount(ResourceType.BRICK);
+        int woolBefore = p1.getResourceCount(ResourceType.WOOL);
+        int bankBrickBefore = freshBank.getResourceCount(ResourceType.BRICK);
+        int bankWoolBefore = freshBank.getResourceCount(ResourceType.WOOL);
+
+        turn.playYearOfPlenty(p1, card, ResourceType.BRICK, ResourceType.WOOL);
+
+        assertAll(
+                () -> assertTrue(card.isPlayed()),
+                () -> assertEquals(brickBefore + 1, p1.getResourceCount(ResourceType.BRICK)),
+                () -> assertEquals(woolBefore + 1, p1.getResourceCount(ResourceType.WOOL)),
+                () -> assertEquals(bankBrickBefore - 1, freshBank.getResourceCount(ResourceType.BRICK)),
+                () -> assertEquals(bankWoolBefore - 1, freshBank.getResourceCount(ResourceType.WOOL)),
+                () -> assertThrows(IllegalStateException.class, () -> turn.playKnightCard(p1, new DevelopmentCard(DevelopmentCardType.KNIGHT)))
+        );
+    }
 }
 
 

--- a/src/test/java/domain/TurnTest.java
+++ b/src/test/java/domain/TurnTest.java
@@ -1660,6 +1660,16 @@ public class TurnTest {
                 () -> turn.playKnightCard(p1, card));
         assertEquals("Player does not own this development card", exception.getMessage());
     }
+
+    @Test
+    void playRoadBuildingCard_CardPurchasedThisTurn_ThrowsIllegalStateException() {
+        Turn turn = newTurnInBuildPhase(p1);
+        DevelopmentCard purchased = buyUntilNonVictoryPointCard(turn, p1);
+
+        IllegalStateException exception = assertThrows(IllegalStateException.class,
+                () -> turn.playRoadBuildingCard(p1, purchased, 0, 1));
+        assertEquals("A development card cannot be played the same turn it was purchased", exception.getMessage());
+    }
 }
 
 

--- a/src/test/java/domain/TurnTest.java
+++ b/src/test/java/domain/TurnTest.java
@@ -1648,6 +1648,18 @@ public class TurnTest {
                 () -> turn.playMonopoly(p1, second, ResourceType.BRICK));
         assertEquals("Only one development card can be played per turn", exception.getMessage());
     }
+
+    @Test
+    void playKnightCard_PlayerDoesNotOwnCard_ThrowsIllegalArgumentException() {
+        DiceRoll fixedDice = mockDiceRoll(4, 4);
+        Turn turn = new Turn(game, p1, fixedDice, bank);
+        turn.rollDice();
+        DevelopmentCard card = new DevelopmentCard(DevelopmentCardType.KNIGHT);
+
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+                () -> turn.playKnightCard(p1, card));
+        assertEquals("Player does not own this development card", exception.getMessage());
+    }
 }
 
 

--- a/src/test/java/domain/TurnTest.java
+++ b/src/test/java/domain/TurnTest.java
@@ -1621,6 +1621,17 @@ public class TurnTest {
                 () -> turn.playRoadBuildingCard(p2, card, 0, 1));
         assertEquals("Only the active player can play a development card", exception.getMessage());
     }
+
+    @Test
+    void playYearOfPlenty_WrongPhase_ThrowsIllegalStateException() {
+        Turn turn = new Turn(game, p1, dice, bank);
+        DevelopmentCard card = new DevelopmentCard(DevelopmentCardType.YEAR_OF_PLENTY);
+        game.addDevelopmentCardToHand(p1, card);
+
+        IllegalStateException exception = assertThrows(IllegalStateException.class,
+                () -> turn.playYearOfPlenty(p1, card, ResourceType.BRICK, ResourceType.WOOL));
+        assertEquals("Development cards can only be played during the trade or build phase", exception.getMessage());
+    }
 }
 
 

--- a/src/test/java/domain/TurnTest.java
+++ b/src/test/java/domain/TurnTest.java
@@ -1778,6 +1778,27 @@ public class TurnTest {
                 () -> turn.playYearOfPlenty(p1, card, ResourceType.BRICK, ResourceType.WOOL));
         assertEquals("Insufficient resources in bank", exception.getMessage());
     }
+
+    @Test
+    void playMonopoly_ValidCard_TakesAllResourceFromOtherPlayers() {
+        DiceRoll fixedDice = mockDiceRoll(4, 4);
+        Turn turn = new Turn(game, p1, fixedDice, bank);
+        turn.rollDice();
+        DevelopmentCard card = new DevelopmentCard(DevelopmentCardType.MONOPOLY);
+        game.addDevelopmentCardToHand(p1, card);
+        p2.addResources(ResourceType.BRICK, 3);
+        p3.addResources(ResourceType.BRICK, 2);
+
+        turn.playMonopoly(p1, card, ResourceType.BRICK);
+
+        assertAll(
+                () -> assertTrue(card.isPlayed()),
+                () -> assertEquals(5, p1.getResourceCount(ResourceType.BRICK)),
+                () -> assertEquals(0, p2.getResourceCount(ResourceType.BRICK)),
+                () -> assertEquals(0, p3.getResourceCount(ResourceType.BRICK)),
+                () -> assertThrows(IllegalStateException.class, () -> turn.playKnightCard(p1, new DevelopmentCard(DevelopmentCardType.KNIGHT)))
+        );
+    }
 }
 
 

--- a/src/test/java/domain/TurnTest.java
+++ b/src/test/java/domain/TurnTest.java
@@ -1714,6 +1714,31 @@ public class TurnTest {
                 () -> assertDoesNotThrow(() -> turn.moveRobber(1))
         );
     }
+
+    @Test
+    void playRoadBuildingCard_ValidCard_PlacesTwoFreeRoads() {
+        Turn turn = newTurnInBuildPhase(p3);
+        DevelopmentCard card = new DevelopmentCard(DevelopmentCardType.ROAD_BUILDING);
+        game.addDevelopmentCardToHand(p3, card);
+
+        board.getEdge(4).getEndpoints().get(0).setOwner(p3);
+        int edge1Id = 4;
+        int edge2Id = 5;
+
+        int brickBefore = p3.getResourceCount(ResourceType.BRICK);
+        int lumberBefore = p3.getResourceCount(ResourceType.LUMBER);
+
+        turn.playRoadBuildingCard(p3, card, edge1Id, edge2Id);
+
+        assertAll(
+                () -> assertTrue(card.isPlayed()),
+                () -> assertTrue(board.getEdge(edge1Id).hasRoad()),
+                () -> assertTrue(board.getEdge(edge2Id).hasRoad()),
+                () -> assertEquals(brickBefore, p3.getResourceCount(ResourceType.BRICK)),
+                () -> assertEquals(lumberBefore, p3.getResourceCount(ResourceType.LUMBER)),
+                () -> assertThrows(IllegalStateException.class, () -> turn.playKnightCard(p3, new DevelopmentCard(DevelopmentCardType.KNIGHT)))
+        );
+    }
 }
 
 

--- a/src/test/java/domain/TurnTest.java
+++ b/src/test/java/domain/TurnTest.java
@@ -1604,7 +1604,22 @@ public class TurnTest {
         Turn turn = new Turn(game, p1, fixedDice, bank);
         turn.rollDice();
 
-        assertThrows(IllegalArgumentException.class, () -> turn.playKnightCard(p1, null));
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+                () -> turn.playKnightCard(p1, null));
+        assertEquals("Development card cannot be null", exception.getMessage());
+    }
+
+    @Test
+    void playRoadBuildingCard_WrongPlayer_ThrowsIllegalArgumentException() {
+        DiceRoll fixedDice = mockDiceRoll(4, 4);
+        Turn turn = new Turn(game, p1, fixedDice, bank);
+        turn.rollDice();
+        DevelopmentCard card = new DevelopmentCard(DevelopmentCardType.ROAD_BUILDING);
+        game.addDevelopmentCardToHand(p1, card);
+
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+                () -> turn.playRoadBuildingCard(p2, card, 0, 1));
+        assertEquals("Only the active player can play a development card", exception.getMessage());
     }
 }
 

--- a/src/test/java/domain/TurnTest.java
+++ b/src/test/java/domain/TurnTest.java
@@ -1556,72 +1556,6 @@ public class TurnTest {
     }
 
     @Test
-    public void PlayDevelopmentCard_OutsideTradeOrBuildPhase_ThrowsIllegalStateException() {
-        Turn turn = new Turn(game, p1, dice, bank);
-        DevelopmentCard card = new DevelopmentCard(DevelopmentCardType.KNIGHT);
-
-        assertThrows(IllegalStateException.class, () -> turn.playDevelopmentCard(p1, card));
-    }
-
-    @Test
-    public void PlayDevelopmentCard_DevCardAlreadyPlayedThisTurn_ThrowsIllegalStateException() {
-        DiceRoll fixedDice = mockDiceRoll(4, 4);
-        Turn turn = new Turn(game, p1, fixedDice, bank);
-        turn.rollDice();
-        DevelopmentCard first = new DevelopmentCard(DevelopmentCardType.KNIGHT);
-        DevelopmentCard second = new DevelopmentCard(DevelopmentCardType.KNIGHT);
-        game.addDevelopmentCardToHand(p1, first);
-        game.addDevelopmentCardToHand(p1, second);
-        turn.playDevelopmentCard(p1, first);
-
-        assertThrows(IllegalStateException.class, () -> turn.playDevelopmentCard(p1, second));
-    }
-
-    @Test
-    public void PlayDevelopmentCard_NonVictoryPointCardPurchasedThisTurn_ThrowsIllegalStateException() {
-        Turn turn = newTurnInBuildPhase(p1);
-        DevelopmentCard purchased = buyUntilNonVictoryPointCard(turn, p1);
-
-        assertThrows(IllegalStateException.class, () -> turn.playDevelopmentCard(p1, purchased));
-    }
-
-    @Test
-    public void PlayDevelopmentCard_CardAlreadyPlayed_ThrowsIllegalStateException() {
-        DiceRoll fixedDice = mockDiceRoll(4, 4);
-        Turn turn = new Turn(game, p1, fixedDice, bank);
-        turn.rollDice();
-        DevelopmentCard card = new DevelopmentCard(DevelopmentCardType.KNIGHT);
-        card.markAsPlayed();
-        game.addDevelopmentCardToHand(p1, card);
-
-        assertThrows(IllegalStateException.class, () -> turn.playDevelopmentCard(p1, card));
-    }
-
-    @Test
-    public void PlayDevelopmentCard_VictoryPointCard_ThrowsIllegalStateException() {
-        DiceRoll fixedDice = mockDiceRoll(4, 4);
-        Turn turn = new Turn(game, p1, fixedDice, bank);
-        turn.rollDice();
-        DevelopmentCard card = new DevelopmentCard(DevelopmentCardType.VICTORY_POINT);
-        game.addDevelopmentCardToHand(p1, card);
-
-        assertThrows(IllegalStateException.class, () -> turn.playDevelopmentCard(p1, card));
-    }
-
-    @Test
-    public void PlayDevelopmentCard_UnplayedCardFromPriorTurn_MarksCardAsPlayed() {
-        DiceRoll fixedDice = mockDiceRoll(4, 4);
-        Turn turn = new Turn(game, p1, fixedDice, bank);
-        turn.rollDice();
-        DevelopmentCard card = new DevelopmentCard(DevelopmentCardType.KNIGHT);
-        game.addDevelopmentCardToHand(p1, card);
-
-        turn.playDevelopmentCard(p1, card);
-
-        assertTrue(card.isPlayed());
-    }
-
-    @Test
     public void GetPlayerHand_PlayerWithNoCards_ReturnsEmptyList() {
         Turn turn = new Turn(game, p1, dice, bank);
 
@@ -1662,6 +1596,15 @@ public class TurnTest {
         turn.buyDevelopmentCard();
 
         assertEquals(24, turn.getRemainingDeckSize());
+    }
+
+    @Test
+    void playKnightCard_NullCard_ThrowsIllegalArgumentException() {
+        DiceRoll fixedDice = mockDiceRoll(4, 4);
+        Turn turn = new Turn(game, p1, fixedDice, bank);
+        turn.rollDice();
+
+        assertThrows(IllegalArgumentException.class, () -> turn.playKnightCard(p1, null));
     }
 }
 

--- a/src/test/java/domain/TurnTest.java
+++ b/src/test/java/domain/TurnTest.java
@@ -1808,8 +1808,14 @@ public class TurnTest {
         DevelopmentCard card = new DevelopmentCard(DevelopmentCardType.MONOPOLY);
         game.addDevelopmentCardToHand(p1, card);
 
-        assertDoesNotThrow(() -> turn.playMonopoly(p1, card, ResourceType.BRICK));
-        assertEquals(0, p1.getResourceCount(ResourceType.BRICK));
+        turn.playMonopoly(p1, card, ResourceType.BRICK);
+
+        assertAll(
+                () -> assertEquals(0, p1.getResourceCount(ResourceType.BRICK)),
+                () -> assertEquals(0, p2.getResourceCount(ResourceType.BRICK)),
+                () -> assertEquals(0, p3.getResourceCount(ResourceType.BRICK)),
+                () -> assertEquals(0, p4.getResourceCount(ResourceType.BRICK))
+        );
     }
 }
 

--- a/src/test/java/domain/TurnTest.java
+++ b/src/test/java/domain/TurnTest.java
@@ -1799,6 +1799,18 @@ public class TurnTest {
                 () -> assertThrows(IllegalStateException.class, () -> turn.playKnightCard(p1, new DevelopmentCard(DevelopmentCardType.KNIGHT)))
         );
     }
+
+    @Test
+    void playMonopoly_OtherPlayersHaveNone_NoChange() {
+        DiceRoll fixedDice = mockDiceRoll(4, 4);
+        Turn turn = new Turn(game, p1, fixedDice, bank);
+        turn.rollDice();
+        DevelopmentCard card = new DevelopmentCard(DevelopmentCardType.MONOPOLY);
+        game.addDevelopmentCardToHand(p1, card);
+
+        assertDoesNotThrow(() -> turn.playMonopoly(p1, card, ResourceType.BRICK));
+        assertEquals(0, p1.getResourceCount(ResourceType.BRICK));
+    }
 }
 
 

--- a/src/test/java/domain/TurnTest.java
+++ b/src/test/java/domain/TurnTest.java
@@ -1765,6 +1765,19 @@ public class TurnTest {
                 () -> assertThrows(IllegalStateException.class, () -> turn.playKnightCard(p1, new DevelopmentCard(DevelopmentCardType.KNIGHT)))
         );
     }
+
+    @Test
+    void playYearOfPlenty_BankEmpty_ThrowsIllegalArgumentException() {
+        DiceRoll fixedDice = mockDiceRoll(4, 4);
+        Turn turn = new Turn(game, p1, fixedDice, bank);
+        turn.rollDice();
+        DevelopmentCard card = new DevelopmentCard(DevelopmentCardType.YEAR_OF_PLENTY);
+        game.addDevelopmentCardToHand(p1, card);
+
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+                () -> turn.playYearOfPlenty(p1, card, ResourceType.BRICK, ResourceType.WOOL));
+        assertEquals("Insufficient resources in bank", exception.getMessage());
+    }
 }
 
 

--- a/src/test/java/domain/TurnTest.java
+++ b/src/test/java/domain/TurnTest.java
@@ -1684,6 +1684,19 @@ public class TurnTest {
                 () -> turn.playYearOfPlenty(p1, card, ResourceType.BRICK, ResourceType.WOOL));
         assertEquals("This development card has already been played", exception.getMessage());
     }
+
+    @Test
+    void playMonopoly_VictoryPointCard_ThrowsIllegalStateException() {
+        DiceRoll fixedDice = mockDiceRoll(4, 4);
+        Turn turn = new Turn(game, p1, fixedDice, bank);
+        turn.rollDice();
+        DevelopmentCard card = new DevelopmentCard(DevelopmentCardType.VICTORY_POINT);
+        game.addDevelopmentCardToHand(p1, card);
+
+        IllegalStateException exception = assertThrows(IllegalStateException.class,
+                () -> turn.playMonopoly(p1, card, ResourceType.BRICK));
+        assertEquals("Victory Point cards cannot be played", exception.getMessage());
+    }
 }
 
 


### PR DESCRIPTION
Implements the effects for each development card type in Turn.java and BuildManager.java. Replaces the old playDevelopmentCard() method with type-specific methods that combine validation and effect execution:
- playKnightCard(): sets robber pending move
- playRoadBuildingCard(): places 2 free roads via BuildManager.buildFreeRoad()
- playYearOfPlenty(): takes 2 resources from bank
- playMonopoly(): takes all of one resource from other players

Includes BVA analysis and TDD tests. Closes #88.